### PR TITLE
Sort, generalize -Failed password- and add now lockout causes

### DIFF
--- a/opnsense/sshlockout_pf/Makefile
+++ b/opnsense/sshlockout_pf/Makefile
@@ -9,6 +9,13 @@ EXTRACT_ONLY=	# empty
 MAINTAINER=	franco@opnsense.org
 COMMENT=	Automatically block IPs with failed SSH logins using pf(4)
 
+OPTIONS_DEFINE= WEBCF
+OPTIONS_DEFAULT= WEBCF
+
+WEBCF_DESC=     Enable webConfigurator support
+
+WEBCF_CFLAGS=           -DWEBCF
+
 PLIST_FILES=    sbin/sshlockout_pf
 
 do-extract:

--- a/opnsense/sshlockout_pf/files/sshlockout_pf.c
+++ b/opnsense/sshlockout_pf/files/sshlockout_pf.c
@@ -223,23 +223,23 @@ main(int argc, char *argv[])
 		if (strstr(buf, "sshd") == NULL && strstr(buf, "webConfigurator") == NULL)
 			continue;
 		// Check for various bad (or good!) strings in stream
-		if (check_for_string("Failed password for root from", "sshlockout", buf, BLOCK))
+		if (check_for_string("Accepted keyboard-interactive/pam for", "sshlockout", buf, RELEASE))
 			continue;
-		else if (check_for_string("Failed password for admin from", "sshlockout",  buf, BLOCK))
+		else if (check_for_string("authentication error for", "sshlockout",  buf, BLOCK))
 			continue;
-		else if (check_for_string("Failed password for invalid user", "sshlockout", buf, BLOCK))
+		else if (check_for_string("Did not receive identification string", "sshlockout", buf, BLOCK))
+			continue;
+		else if (check_for_string("Failed password for", "sshlockout", buf, BLOCK))
 			continue;
 		else if (check_for_string("Illegal user", "sshlockout", buf, BLOCK))
 			continue;
 		else if (check_for_string("Invalid user", "sshlockout", buf, BLOCK))
 			continue;
+		else if (check_for_string("Postponed keyboard-interactive for invalid user", "sshlockout", buf, BLOCK))
+			continue;
 		else if (check_for_string("webConfigurator authentication error for", "webConfiguratorlockout", buf, BLOCK))
 			continue;
-		else if (check_for_string("authentication error for", "sshlockout", buf, BLOCK))
-			continue;
 		else if (check_for_string("Successful webConfigurator login for user", "webConfiguratorlockout", buf, RELEASE))
-			continue;
-		else if (check_for_string("Accepted keyboard-interactive/pam for", "sshlockout", buf, RELEASE))
 			continue;
 	}
 


### PR DESCRIPTION
Hi,
this change tries to fetch all "Failed password" attemts for any user.
Additionally it tries to lock:
- "authentication error for"
- "Did not receive identification string"
- "Postponed keyboard-interactive for invalid user"