### PR TITLE
Error writing to syslog

### DIFF
--- a/www/havp/files/patch-havp_logfile.cpp
+++ b/www/havp/files/patch-havp_logfile.cpp
@@ -1,0 +1,14 @@
+--- havp/logfile.cpp.orig	2016-06-27 14:16:19.640229000 +0300
++++ havp/logfile.cpp		2016-06-27 14:25:01.272114000 +0300
+@@ -52,7 +52,10 @@
+         SyslogLevel = GetSyslogLevel();
+         SyslogVirusLevel = GetSyslogVirusLevel();
+ 
+-        openlog(Params::GetConfigString("SYSLOGNAME").c_str(), LOG_CONS | LOG_PID, GetSyslogFacility());
++        // FreeBSD don't copy ident, only pointer to ident. So we need store ident itself
++        static string SyslogName;
++        SyslogName = Params::GetConfigString("SYSLOGNAME");
++        openlog(SyslogName.c_str(), LOG_CONS | LOG_PID, GetSyslogFacility());
+ 
+         return true;
+     }


### PR DESCRIPTION
In syslog writed:
Jun 27 12:26:16 freebsd <D9><FF><FF><FF>^?[24629]: === Starting HAVP Version: 0.91
Jun 27 12:26:16 freebsd <D9><FF><FF><FF>^?[24629]: === Mandatory locking disabled! KEEPBACK settings not used!
Jun 27 12:26:17 freebsd <D9><FF><FF><FF>^?[24629]: Running as user: kekek, group: kekek
Jun 27 12:26:17 freebsd IMEOUT[24629]: --- Initializing ClamAV Library Scanner
Jun 27 12:26:17 freebsd IMEOUT[24629]: ClamAV: Using database directory: /var/db/clamav
Jun 27 12:26:27 freebsd IMEOUT[24629]: ClamAV: Loaded 4562801 signatures (engine 0.99.2)
Jun 27 12:26:31 freebsd IMEOUT[24629]: ClamAV Library Scanner passed EICAR virus test (Eicar-Test-Signature)
Jun 27 12:26:31 freebsd IMEOUT[24629]: --- All scanners initialized