### PR TITLE
dhcp6c update : Added RAW options; Added re-read config on sigup

### DIFF
--- a/net/dhcp6/files/patch-cfparse.y
+++ b/net/dhcp6/files/patch-cfparse.y
@@ -1,0 +1,88 @@
+--- cfparse.y.orig	2017-02-28 19:06:15 UTC
++++ cfparse.y
+@@ -41,6 +41,11 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
++/* XXX */
++
++#include <stdio.h>
++#include <ctype.h>
++
+ #include "dhcp6.h"
+ #include "config.h"
+ #include "common.h"
+@@ -145,6 +150,9 @@ static void cleanup_cflist __P((struct c
+ %type <range> rangeparam
+ %type <pool> poolparam
+ 
++/* XXX */
++%token RAW
++
+ %%
+ statements:
+ 		/* empty */
+@@ -664,6 +672,63 @@ dhcpoption:
+ 			/* currently no value */
+ 			$$ = l;
+ 		}
++	/* XXX */
++	|	RAW NUMBER STRING
++		{		
++			struct cf_list *l;
++			struct rawoption *rawop;
++			char *tmp, *opstr = $2, *datastr = $3;
++
++			yywarn("Got raw option: %s %s", opstr, datastr);			
++			
++			if ((rawop = malloc(sizeof(*rawop))) == NULL) {
++				yywarn("can't allocate memory");
++				free(datastr);
++				free(opstr);
++				return (-1);
++			}
++			
++			/* convert op num */
++			rawop->opnum = (int)strtol(opstr, NULL, 10);
++						
++			/* convert string to lowercase */
++			tmp = datastr;
++			for ( ; *tmp; ++tmp) *tmp = tolower(*tmp);
++			
++			/* allocate buffer */
++			int len = strlen(datastr);
++			len -= len / 3; /* remove ':' from length */						
++			len = len / 2; /* byte length */			
++			rawop->datalen = len;
++			
++			if ((rawop->data = malloc(len)) == NULL) {
++				yywarn("can't allocate memory");
++				free(datastr);
++				free(opstr);
++				return (-1);
++			}
++			
++			/* convert hex string to byte array */					
++			char *h = datastr;
++			char *b = rawop->data;
++			char xlate[] = "0123456789abcdef";
++			int p1, p2, i = 0;
++
++			for ( ; *h; h += 3, ++b) { /* string is xx(:xx)\0 */
++				p1 = (int)(strchr(xlate, *h) - xlate);
++				p2 = (int)(strchr(xlate, *(h+1)) - xlate);
++				*b = (char)((p1 * 16) + p2);
++			}   
++			//free(datastr);
++			//free(opstr);
++
++			yywarn("Raw option %d length %d stored at %p with data at %p",
++				rawop->opnum, rawop->datalen, (void*)rawop, (void*)rawop->data);			
++			
++			MAKE_CFLIST(l, DHCPOPT_RAW, NULL, NULL);
++			l->ptr = rawop;
++			$$ = l;
++		}
+ 	|	DNS_SERVERS
+ 		{
+ 			struct cf_list *l;

--- a/net/dhcp6/files/patch-cftoken.l
+++ b/net/dhcp6/files/patch-cftoken.l
@@ -1,4 +1,4 @@
---- cftoken.l.orig	2016-12-19 08:16:42 UTC
+--- cftoken.l.orig	2017-02-28 19:06:15 UTC
 +++ cftoken.l
 @@ -1,5 +1,7 @@
  /*	$KAME: cftoken.l,v 1.35 2005/01/12 06:06:11 suz Exp $	*/
@@ -8,3 +8,38 @@
  %{
  /*
   * Copyright (C) 2002 WIDE Project.
+@@ -109,6 +111,9 @@ slash		\/
+ bcl		\{
+ ecl		\}
+ 
++/* XXX */
++hexdata 	{hexpair}(:{hexpair})*
++
+ %s S_CNF
+ %s S_IFACE
+ %s S_PREF
+@@ -120,6 +125,8 @@ ecl		\}
+ %s S_SECRET
+ %s S_ADDRPOOL
+ %s S_INCL
++/* XXX */
++%s S_RAW
+ 
+ %%
+ %{
+@@ -205,6 +212,15 @@ ecl		\}
+ <S_CNF>bcmcs-server-address { DECHO; return (BCMCS_SERVERS); }
+ <S_CNF>bcmcs-server-domain-name { DECHO; return (BCMCS_NAME); }
+ <S_CNF>refreshtime { DECHO; return (REFRESHTIME); }
++	/* XXX */
++<S_CNF>raw-option { DECHO; BEGIN S_RAW; return (RAW); }
++<S_RAW>{integer} { DECHO; yylval.str = strdup(yytext); return(NUMBER); }
++<S_RAW>{hexdata} {
++	DECHO;
++	yylval.str = strdup(yytext);
++	BEGIN S_CNF;
++	return (STRING);
++}
+ 
+ 	/* provided for a backward compatibility to WIDE-DHCPv6 before Oct 1 2006 */
+ <S_CNF>nis-server-domain-name { DECHO; return (NIS_NAME); }

--- a/net/dhcp6/files/patch-common.c
+++ b/net/dhcp6/files/patch-common.c
@@ -1,0 +1,225 @@
+--- common.c.orig	2017-02-28 19:06:15 UTC
++++ common.c
+@@ -114,6 +114,105 @@ static ssize_t gethwid __P((char *, int,
+ static char *sprint_uint64 __P((char *, int, u_int64_t));
+ static char *sprint_auth __P((struct dhcp6_optinfo *));
+ 
++/* XXX */
++int
++rawop_count_list(head)
++	struct rawop_list *head;
++{
++	struct rawoption *op;
++	int i;
++
++	//dprintf(LOG_INFO, FNAME, "counting list at %p", (void*)head);
++	
++	for (i = 0, op = TAILQ_FIRST(head); op; op = TAILQ_NEXT(op, link)) {
++		i++;
++	}
++
++	return (i);
++}
++
++void
++rawop_clear_list(head)
++	struct rawop_list *head;
++{
++	struct rawoption *op;
++	
++	//dprintf(LOG_INFO, FNAME, "clearing %d rawops at %p", rawop_count_list(head), (void*)head);
++	
++	while ((op = TAILQ_FIRST(head)) != NULL) {
++		
++		//dprintf(LOG_INFO, FNAME, "  current op: %p link: %p", (void*)op, op->link);
++		TAILQ_REMOVE(head, op, link);
++		
++		if (op->data != NULL) {
++			d_printf(LOG_INFO, FNAME, "    freeing op data at %p", (void*)op->data);
++			free(op->data);	
++		}
++		free(op);	// Needed?
++	}	
++	return;
++}
++
++int
++rawop_copy_list(dst, src)
++	struct rawop_list *dst, *src;
++{
++	struct rawoption *op, *newop;	
++	
++	/*
++	d_printf(LOG_INFO, FNAME,
++		"  copying rawop list %p to %p (%d ops)",
++		(void*)src, (void*)dst, rawop_count_list(src));
++	*/
++	
++	for (op = TAILQ_FIRST(src); op; op = TAILQ_NEXT(op, link)) {
++		newop = NULL;
++		if ((newop = malloc(sizeof(*newop))) == NULL) {
++			d_printf(LOG_ERR, FNAME,
++				"failed to allocate memory for a new raw option");
++			goto fail;
++		}
++		memset(newop, 0, sizeof(*newop));
++
++		newop->opnum = op->opnum;
++		newop->datalen = op->datalen;	
++		newop->data = NULL;
++		
++		/* copy data */
++		if ((newop->data = malloc(newop->datalen)) == NULL) {
++			d_printf(LOG_ERR, FNAME,
++				"failed to allocate memory for new raw option data");
++			goto fail;
++		}
++		memcpy(newop->data, op->data, newop->datalen);
++		//dprintf(LOG_INFO, FNAME, "    copied %d bytes of data at %p", newop->datalen, (void*)newop->data);		
++			
++		TAILQ_INSERT_TAIL(dst, newop, link);
++	}
++	return (0);
++	
++  fail:
++	rawop_clear_list(dst);
++	return (-1);	
++}
++
++void
++rawop_move_list(dst, src)
++	struct rawop_list *dst, *src;
++{
++	struct rawoption *op;
++	/*
++	d_printf(LOG_INFO, FNAME,
++		"  moving rawop list of %d from %p to %p",
++		rawop_count_list(src), (void*)src, (void*)dst);	
++	*/
++	while ((op = TAILQ_FIRST(src)) != NULL) {
++		TAILQ_REMOVE(src, op, link);
++		TAILQ_INSERT_TAIL(dst, op, link);
++	}
++}
++
++
+ int
+ dhcp6_copy_list(dst, src)
+ 	struct dhcp6_list *dst, *src;
+@@ -1337,6 +1436,9 @@ dhcp6_init_options(optinfo)
+ 	TAILQ_INIT(&optinfo->bcmcs_list);
+ 	TAILQ_INIT(&optinfo->bcmcsname_list);
+ 
++	/* XXX */
++	TAILQ_INIT(&optinfo->rawops);
++
+ 	optinfo->authproto = DHCP6_AUTHPROTO_UNDEF;
+ 	optinfo->authalgorithm = DHCP6_AUTHALG_UNDEF;
+ 	optinfo->authrdm = DHCP6_AUTHRDM_UNDEF;
+@@ -1380,6 +1482,9 @@ dhcp6_clear_options(optinfo)
+ 	if (optinfo->ifidopt_id != NULL)
+ 		free(optinfo->ifidopt_id);
+ 
++	/* XXX */
++	rawop_clear_list(&optinfo->rawops);
++
+ 	dhcp6_init_options(optinfo);
+ }
+ 
+@@ -1429,6 +1534,9 @@ dhcp6_copy_options(dst, src)
+ 	dst->refreshtime = src->refreshtime;
+ 	dst->pref = src->pref;
+ 
++	/* XXX */
++	rawop_copy_list(&dst->rawops, &src->rawops);
++
+ 	if (src->relaymsg_msg != NULL) {
+ 		if ((dst->relaymsg_msg = malloc(src->relaymsg_len)) == NULL)
+ 			goto fail;
+@@ -1497,6 +1605,9 @@ dhcp6_get_options(p, ep, optinfo)
+ 	struct dhcp6_list sublist;
+ 	int authinfolen;
+ 
++	/* XXX */
++	struct rawoption *rawop;
++
+ 	bp = (char *)p;
+ 	for (; p + 1 <= ep; p = np) {
+ 		struct duid duid0;
+@@ -1697,6 +1808,15 @@ dhcp6_get_options(p, ep, optinfo)
+ 			case DHCP6_AUTHPROTO_RECONFIG:
+ 				break;
+ #endif
++			/* XXX */
++			case 0:
++				// Discard auth
++				d_printf(LOG_DEBUG, FNAME, "  Discarding null authentication");
++				optinfo->authproto = DHCP6_AUTHPROTO_UNDEF;
++				optinfo->authalgorithm = DHCP6_AUTHALG_UNDEF;
++				optinfo->authrdm = DHCP6_AUTHRDM_UNDEF;
++				break;
++
+ 			default:
+ 				d_printf(LOG_INFO, FNAME,
+ 				    "unsupported authentication protocol: %d",
+@@ -1872,6 +1992,16 @@ dhcp6_get_options(p, ep, optinfo)
+ 			dhcp6_clear_list(&sublist);
+ 
+ 			break;
++			
++		/* XX */		
++		case DHCPOPT_RAW:
++			rawop = (struct rawoption *) cp;
++			d_printf(LOG_DEBUG, FNAME,
++				"raw option: %d",
++				rawop->opnum);				
++			TAILQ_INSERT_TAIL(&optinfo->rawops, rawop, link);			
++			break;			
++
+ 		default:
+ 			/* no option specific behavior */
+ 			d_printf(LOG_INFO, FNAME,
+@@ -2248,6 +2378,8 @@ dhcp6_set_options(type, optbp, optep, op
+ 	struct dhcp6_listval *stcode, *op;
+ 	int len = 0, optlen;
+ 	char *tmpbuf = NULL;
++	/* XXX */
++	struct rawoption *rawop;
+ 
+ 	if (optinfo->clientID.duid_len) {
+ 		if (copy_option(DH6OPT_CLIENTID, optinfo->clientID.duid_len,
+@@ -2471,6 +2603,21 @@ dhcp6_set_options(type, optbp, optep, op
+ 			goto fail;
+ 		}
+ 	}
++	/* XXX */
++	for (rawop = TAILQ_FIRST(&optinfo->rawops); rawop;
++	    rawop = TAILQ_NEXT(rawop, link)) {
++			
++		d_printf(LOG_DEBUG, FNAME,
++			"  raw option %d length %d at %p",
++			rawop->opnum, rawop->datalen, (void*)rawop);
++			
++		if (copy_option(rawop->opnum, rawop->datalen,
++			rawop->data, &p,
++		    optep, &len) != 0) {
++			goto fail;
++		}
++	}
++	
+ 
+ 	if (optinfo->authproto != DHCP6_AUTHPROTO_UNDEF) {
+ 		struct dhcp6opt_auth *auth;
+@@ -3051,7 +3198,11 @@ dhcp6optstr(type)
+ 	case DH6OPT_SUBSCRIBER_ID:
+ 		return ("subscriber ID");
+ 	case DH6OPT_CLIENT_FQDN:
+-		return ("client FQDN");
++		return ("client FQDN");		
++	/* XXX */
++	case DHCPOPT_RAW:
++		return ("raw");
++
+ 	default:
+ 		snprintf(genstr, sizeof(genstr), "opt_%d", type);
+ 		return (genstr);

--- a/net/dhcp6/files/patch-config.c
+++ b/net/dhcp6/files/patch-config.c
@@ -1,0 +1,130 @@
+--- config.c.orig	2017-02-28 19:06:15 UTC
++++ config.c
+@@ -106,6 +106,10 @@ struct dhcp6_ifconf {
+ 	int server_pref;	/* server preference (server only) */
+ 
+ 	char *scriptpath;	/* path to config script (client only) */
++	
++	/* XXX */
++	struct duid duid;	
++	struct rawop_list rawops;
+ 
+ 	struct dhcp6_list reqopt_list;
+ 	struct ia_conflist iaconf_list;
+@@ -179,6 +183,10 @@ configure_interface(iflist)
+ 		TAILQ_INIT(&ifc->reqopt_list);
+ 		TAILQ_INIT(&ifc->iaconf_list);
+ 
++		/* XXX */
++		TAILQ_INIT(&ifc->rawops);
++	
++
+ 		for (cfl = ifp->params; cfl; cfl = cfl->next) {
+ 			switch(cfl->type) {
+ 			case DECL_REQUEST:
+@@ -206,6 +214,22 @@ configure_interface(iflist)
+ 					goto bad;
+ 				}
+ 				break;
++			/* XXX */
++			case DECL_DUID:
++				if ((configure_duid((char *)cfl->ptr,
++						    &ifc->duid)) != 0) {
++					d_printf(LOG_ERR, FNAME, "%s:%d "
++					    "failed to configure "
++					    "DUID for %s",
++					    configfilename, cfl->line,
++					    ifc->ifname);
++					goto bad;
++				}
++				d_printf(LOG_DEBUG, FNAME,
++				    "configure DUID for %s: %s",
++				    ifc->ifname, duidstr(&ifc->duid));					
++				break;
++
+ 			case DECL_INFO_ONLY:
+ 				if (dhcp6_mode != DHCP6_MODE_CLIENT) {
+ 					d_printf(LOG_INFO, FNAME, "%s:%d "
+@@ -1302,6 +1326,10 @@ configure_commit()
+ 	struct dhcp6_ifconf *ifc;
+ 	struct dhcp6_if *ifp;
+ 	struct ia_conf *iac;
++	/* XXX */
++	struct rawoption *rawop;
++
++	static int init = 1;	
+ 
+ 	/* commit interface configuration */
+ 	for (ifp = dhcp6_if; ifp; ifp = ifp->next) {
+@@ -1310,6 +1338,15 @@ configure_commit()
+ 		ifp->allow_flags = 0;
+ 		dhcp6_clear_list(&ifp->reqopt_list);
+ 		clear_iaconf(&ifp->iaconf_list);
++
++		/* XXX */
++		if (init) {
++			TAILQ_INIT(&ifp->rawops);
++			init = 0;
++		} else {
++			rawop_clear_list(&ifp->rawops);			
++		}
++
+ 		ifp->server_pref = DH6OPT_PREF_UNDEF;
+ 		if (ifp->scriptpath != NULL)
+ 			free(ifp->scriptpath);
+@@ -1345,7 +1382,27 @@ configure_commit()
+ 		}
+ 		ifp->pool = ifc->pool;
+ 		ifc->pool.name = NULL;
++
++		
++		/* XXX */
++		if (ifc->duid.duid_id != NULL) {
++			dprintf(LOG_INFO, FNAME, "copying duid");				
++			duidcpy(&ifp->duid, &ifc->duid);
++		}
++ 
++		dprintf(LOG_DEBUG,
++			"conf_commit: copying %d rawops from %p (ifc) to %p (ifp)",
++			rawop_count_list(&ifc->rawops), &ifc->rawops, &ifp->rawops);			
++		rawop_clear_list(&ifp->rawops);	
++		rawop_copy_list(&ifp->rawops, &ifc->rawops); // XXX: breaks if move instead of copy
++
++			
+ 	}
++	
++	/* XXX*/
++	rawop_clear_list(&ifc->rawops);		
++	duidfree(&ifc->duid);
++	
+ 
+ 	clear_ifconf(dhcp6_ifconflist);
+ 	dhcp6_ifconflist = NULL;
+@@ -1545,6 +1602,9 @@ add_options(opcode, ifc, cfl0)
+ 	int opttype;
+ 	struct authinfo *ainfo;
+ 	struct ia_conf *iac;
++	/* XXX */
++	char *cp;
++	struct rawoption *rawopc;
+ 
+ 	for (cfl = cfl0; cfl; cfl = cfl->next) {
+ 		switch(cfl->type) {
+@@ -1638,6 +1698,17 @@ add_options(opcode, ifc, cfl0)
+ 				break;
+ 			}
+ 			break;
++			
++		/* XXX */
++		case DHCPOPT_RAW:
++			opttype = DHCPOPT_RAW;
++			rawopc = (struct rawoption *) cfl->ptr;
++			dprintf(LOG_INFO, FNAME,
++				"add raw option: %d length: %d",
++				rawopc->opnum, rawopc->datalen);
++			TAILQ_INSERT_TAIL(&ifc->rawops, rawopc, link);	
++			break;
++	
+ 		case DHCPOPT_SIP:
+ 		case DHCPOPT_SIPNAME:
+ 		case DHCPOPT_DNS:

--- a/net/dhcp6/files/patch-config.h
+++ b/net/dhcp6/files/patch-config.h
@@ -1,0 +1,25 @@
+--- config.h.orig	2017-02-28 19:06:15 UTC
++++ config.h
+@@ -80,6 +80,10 @@ struct dhcp6_if {
+ 	struct dhcp6_poolspec pool;	/* address pool (server only) */
+ 	char *scriptpath;	/* path to config script (client only) */
+ 
++	/* XXX */
++	struct duid duid;
++	struct rawop_list rawops;
++
+ 	struct dhcp6_list reqopt_list;
+ 	struct ia_conflist iaconf_list;
+ 
+@@ -279,7 +283,10 @@ enum { DECL_SEND, DECL_ALLOW, DECL_INFO_
+        IACONF_PIF, IACONF_PREFIX, IACONF_ADDR,
+        DHCPOPT_SIP, DHCPOPT_SIPNAME,
+        AUTHPARAM_PROTO, AUTHPARAM_ALG, AUTHPARAM_RDM, AUTHPARAM_KEY,
+-       KEYPARAM_REALM, KEYPARAM_KEYID, KEYPARAM_SECRET, KEYPARAM_EXPIRE };
++      KEYPARAM_REALM, KEYPARAM_KEYID, KEYPARAM_SECRET, KEYPARAM_EXPIRE,
++       /* XXX */
++       DHCPOPT_RAW
++    };
+ 
+ typedef enum {DHCP6_MODE_SERVER, DHCP6_MODE_CLIENT, DHCP6_MODE_RELAY }
+ dhcp6_mode_t;

--- a/net/dhcp6/files/patch-dhcp6.h
+++ b/net/dhcp6/files/patch-dhcp6.h
@@ -1,0 +1,30 @@
+--- dhcp6.h.orig	2017-02-28 19:06:15 UTC
++++ dhcp6.h
+@@ -108,6 +108,17 @@ typedef uint64_t u_int64_t;
+ #define DHCP6_IRT_DEFAULT 86400	/* 1 day */
+ #define DHCP6_IRT_MINIMUM 600
+ 
++/* XXX */
++TAILQ_HEAD(rawop_list, rawoption);
++struct rawoption {
++	TAILQ_ENTRY(rawoption) link;
++	
++	int opnum;
++	char *data;
++	int datalen;
++};
++
++
+ /* DUID: DHCP unique Identifier */
+ struct duid {
+ 	size_t duid_len;	/* length */
+@@ -197,6 +208,9 @@ struct dhcp6_optinfo {
+ 	struct dhcp6_list nispname_list; /* NIS+ domain list */
+ 	struct dhcp6_list bcmcs_list; /* BCMC server list */
+ 	struct dhcp6_list bcmcsname_list; /* BCMC domain list */
++	/* XXX */
++	struct rawop_list rawops;
++	
+ 
+ 	struct dhcp6_vbuf relay_msg; /* relay message */
+ #define relaymsg_len relay_msg.dv_len

--- a/net/dhcp6/files/patch-dhcp6c.c
+++ b/net/dhcp6/files/patch-dhcp6c.c
@@ -1,0 +1,30 @@
+--- dhcp6c.c.orig	2017-02-28 19:06:15 UTC
++++ dhcp6c.c
+@@ -521,6 +521,7 @@ process_signals()
+ 	if ((sig_flags & SIGF_HUP)) {
+ 		d_printf(LOG_INFO, FNAME, "restarting");
+ 		free_resources(NULL);
++		cfparse(conffile);
+ 		client6_startall(1);
+ 	}
+ 	if ((sig_flags & SIGF_USR1)) {
+@@ -1192,6 +1193,8 @@ client6_send(ev)
+ 	struct dhcp6_optinfo optinfo;
+ 	ssize_t optlen, len;
+ 	struct dhcp6_eventdata *evd;
++	/* XXX */
++	struct rawoption *rawop;
+ 
+ 	ifp = ev->ifp;
+ 
+@@ -1350,6 +1353,10 @@ client6_send(ev)
+ 		    "failed to set authentication option");
+ 		goto end;
+ 	}
++	/* XXX */
++	rawop_clear_list(&optinfo.rawops);
++	rawop_copy_list(&optinfo.rawops, &ifp->rawops);
++
+ 
+ 	/* set options in the message */
+ 	if ((optlen = dhcp6_set_options(dh6->dh6_msgtype,


### PR DESCRIPTION
In its current form dhcp6c is limited by the number of OPTIONS that can be sent. This means that for certain ISP's it will not work.

The changes here add the ability to add as many options as needed using the RAW parameter.

For example, these are taken from a working system.

User class "+FSVDSL_livebox.Internet.softathome.Livebox3";

send raw-option 15 00:2b:46:53:56:44:53:4c:5f:6c:69:76:65:62:6f:78:2e:49:6e:74:65:72:6e:65:74:2e:73:6f:66:74:61:74:68:6f:6d:65:2e:6c:69:76:65:62:6f:78:33;

Vendor class "sagem"

send raw-option 16 00:00:04:0e:00:05:73:61:67:65:6d;

Authentication

send raw-option 11 00:00:00:00:00:00:00:00:00:00:00:61:71:81:2d:66:73:71:71:36:41:78;

It can be seen that the option number is the first number after the "send raw-option, entered as a decimal number.

For example, in the User Class, rfc3315 states that for user class, all that is required is the option length - first byte, then the string itself. As the length will be calculated and entered automatically this is set to 0, or in hex 00. The string is then entered, converted to hex bytes as shown below.

+FSVDSL_livebox.Internet.softathome.Livebox3

becomes

00:2b:46:53:56:44:53:4c:5f:6c:69:76:65:62:6f:78:2e:49:6e:74:65:72:6e:65:74:2e:73:6f:66:74:61:74:68:6f:6d:65:2e:6c:69:76:65:62:6f:78:33

Care obviously needs to be taken when creating these parameters and it is for the advanced only, but it does allow any option(s) to be added, and it works!

Added the feature that dhcp6c will now re-read its config on sigup. This means it is no longer a requirement to terminate the process and restart it on a change to WAN or LAN (tracking). 