### PR TITLE
udpbroadcastrelay - UDP unicast/multicast relayer  for the likes of Sonos etc. 

### DIFF
--- a/net/udpbroadcastrelay/CONTRIBUTORS.md
+++ b/net/udpbroadcastrelay/CONTRIBUTORS.md
@@ -1,0 +1,29 @@
+CONTRIBUTORS
+-----------------
+
+(Reverse chronological)
+
+-   [Martin Wasley](https://github.com/marjohn56) forked to
+    udpbroadcastrelay, added support for pid generation with id when in
+    backround mode.
+-   [Michael Morrison](https://github.com/sonicsnes) forked to
+    udp-broadcast-relay-redux, refactored the code, added support for
+    FreeBSD / pfSense, multicast packets, and interface source address.
+-   udp-broadcast-relay-redux was based on udp-broadcast-relay by
+    [Joachim Breitner](https://github.com/nomeata).
+-   Patrick Huesmann submitted a patch to make udp-broadcast-relay send
+    the packes to those NICs it did not recieve it from, based on the
+    actual socket, not the broadcast IP. This is useful if more than one
+    physical networks share the same broadcast range.
+-   Савченко В. М. submitted an `ip-up.local` an `ip-down.local` file to
+    automatically restart udp-broadcast-relay when new ppp-interfaces
+    come up, see `ppp-if.up-local` for details.
+-   Roman Hoog Antink contributed the option `-s` to spoof the source IP of
+    forwarded packages.
+- udp-broadcast-relay was based on
+  [udp_broadcast_fw](http://www.serverquery.com/udp_broadcast_fw/)
+  by Nathan O'Sullivan.
+- Arny <cs6171@scitsc.wlv.ac.uk> (public domain UDP spoofing code)
+- http://www.netfor2.com/ip.htm (IP/UDP packet formatting info)
+
+Thanks to all contributors!

--- a/net/udpbroadcastrelay/CONTRIBUTORS.md
+++ b/net/udpbroadcastrelay/CONTRIBUTORS.md
@@ -2,10 +2,12 @@ CONTRIBUTORS
 -----------------
 
 (Reverse chronological)
-
--   [Martin Wasley](https://github.com/marjohn56) forked to
-    udpbroadcastrelay, added support for pid generation with id when in
-    backround mode.
+-   [Martin Wasley, Berto Furth] (https://github.com/marjohn56 ,
+    https://github.com/bertofurth/ ) Changed default packet
+    marking to use IP DSCP to cater for TTL sensitive protocols.
+    Added "-t|-ttl-id" to revert to original TTL marking,
+    "-h|--help" for descriptive help, signal handling and pid file
+    creation when run in background.
 -   [Michael Morrison](https://github.com/sonicsnes) forked to
     udp-broadcast-relay-redux, refactored the code, added support for
     FreeBSD / pfSense, multicast packets, and interface source address.

--- a/net/udpbroadcastrelay/LICENSE
+++ b/net/udpbroadcastrelay/LICENSE
@@ -1,0 +1,339 @@
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+                          675 Mass Ave, Cambridge, MA 02139, USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 19yy  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) 19yy name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General
+Public License instead of this License.

--- a/net/udpbroadcastrelay/Makefile
+++ b/net/udpbroadcastrelay/Makefile
@@ -1,0 +1,5 @@
+udp-broadcast-relay-redux: main.c
+	$(CC) $(CFLAGS) -g main.c -o udpbroadcastrelay
+
+clean:
+	rm -f udpbroadcastrelay

--- a/net/udpbroadcastrelay/README.md
+++ b/net/udpbroadcastrelay/README.md
@@ -1,0 +1,80 @@
+UDP Broadcast Relay for Linux / FreeBSD / pfSense /OPNsense
+==========================
+
+This program listens for packets on a specified UDP broadcast port. When
+a packet is received, it sends that packet to all specified interfaces
+but the one it came from as though it originated from the original
+sender.
+
+The primary purpose of this is to allow devices or game servers on separated
+local networks (Ethernet, WLAN, VLAN) that use udp broadcasts to find each
+other to do so.
+
+INSTALL
+-------
+
+    make
+    cp udpbroadcastrelay /some/where
+
+USAGE
+-----
+
+```
+./udp-broadcastrelay \
+    -id id \
+    --port <udp-port> \
+    --dev eth0 \
+    [--dev eth1...] \
+    [--multicast 224.0.0.251] \
+    [-s <spoof_source_ip>]
+```
+
+- udpbroadcastrelay must be run as root to be able to create a raw
+  socket (necessary) to send packets as though they originated from the
+  original sender.
+- `id` must be unique number between instances. This is used to set the TTL of
+  outgoing packets to determine if a packet is an echo and should be discarded.
+- Multicast groups can be joined and relayed with
+  `--multicast <group address>`.
+- The source address for all packets can be modified with `-s <ip>`. This
+  is unusual.
+- A special source ip of `-s 1.1.1.1` can be used to set the source ip
+  to the address of the outgoing interface.
+- `-f` will fork the application to the background. It will also generate a
+  pid file in /var/run with the name udpbroadcastrelay_id.pid, where ID is the id
+  is that set as the instance id.
+
+EXAMPLE
+-------
+
+#### mDNS / Multicast DNS (Chromecast Discovery + Bonjour + More)
+`./udpbroadcastrelay --id 1 --port 5353 --dev eth0 --dev eth1 --multicast 224.0.0.251 -s 1.1.1.1`
+
+(Chromecast requires broadcasts to originate from an address on its subnet)
+
+#### SSDP (Roku Discovery + More)
+`./udpbroadcastrelay --id 1 --port 1900 --dev eth0 --dev eth1 --multicast 239.255.255.250`
+
+#### Lifx Bulb Discovery
+`./udpbroadcastrelay --id 1 --port 56700 --dev eth0 --dev eth1`
+
+#### Broadlink IR Emitter Discovery
+`./udpbroadcastrelay --id 1 --port 80 --dev eth0 --dev eth1`
+
+#### Warcraft 3 Server Discovery
+`./udpbroadcastrelay --id 1 --port 6112 --dev eth0 --dev eth1`
+
+Note about firewall rules
+---
+
+If you are running udpbroadcastrelay on a router, it can be an easy
+way to relay broadcasts between VLANs. However, beware that these broadcasts
+will not establish a RELATED firewall relationship between the source and
+destination addresses.
+
+This means if you have strict firewall rules, the recipient may not be able
+to respond to the broadcaster. For instance, the SSDP protocol involves
+sending a broadcast packet to port 1900 to discover devices on the network.
+The devices then respond to the broadcast with a unicast packet back to the
+original sender. You will need to make sure that your firewall rules allow
+these response packets to make it back to the original sender.

--- a/net/udpbroadcastrelay/README.md
+++ b/net/udpbroadcastrelay/README.md
@@ -1,4 +1,4 @@
-UDP Broadcast Relay for Linux / FreeBSD / pfSense /OPNsense
+UDP Broadcast Relay for Linux / FreeBSD / pfSense / OPNsense
 ==========================
 
 This program listens for packets on a specified UDP broadcast port. When
@@ -20,29 +20,46 @@ USAGE
 -----
 
 ```
-./udp-broadcastrelay \
+./udpbroadcastrelay \
     -id id \
     --port <udp-port> \
-    --dev eth0 \
-    [--dev eth1...] \
+    --dev eth0 --dev eth1
+    [--dev ethx...] \
     [--multicast 224.0.0.251] \
     [-s <spoof_source_ip>]
+    [-t|--ttl-id] [-d] [-f]
+    [-h|--help]
 ```
 
 - udpbroadcastrelay must be run as root to be able to create a raw
   socket (necessary) to send packets as though they originated from the
   original sender.
-- `id` must be unique number between instances. This is used to set the TTL of
-  outgoing packets to determine if a packet is an echo and should be discarded.
-- Multicast groups can be joined and relayed with
+- `id` must be unique number between instances with range 1 - 63. This is
+  used to set the DSCP of outgoing packets to determine if a packet is an
+  echo and should be discarded.
+- `udp-port` Destination udp port to listen to. Range 1 - 65535.
+  Example values for common services are given below.
+- `-dev <ethx>` specifies the name of an interface to receive and
+  transmit packets on. This option needs to be specified at least twice
+  for 2 separate interfaces otherwise this tool won't actually do
+  anything!
+- The tool can listen for and relay packets using multicast groups
+  with
   `--multicast <group address>`.
 - The source address for all packets can be modified with `-s <ip>`. This
   is unusual.
 - A special source ip of `-s 1.1.1.1` can be used to set the source ip
-  to the address of the outgoing interface.
-- `-f` will fork the application to the background. It will also generate a
-  pid file in /var/run with the name udpbroadcastrelay_id.pid, where ID is the id
-  is that set as the instance id.
+  to the address of the outgoing interface and the source UDP port to the
+  same as the destination port. '-s 1.1.1.2' does the same but leaves
+  the UDP ports unchanged. These values are notably required to cater
+  for the Chromecast system.
+- The original version of this tool marked the TTL of outgoing relayed
+  packets to detect echos and preserved DSCP. This original behavior can
+  be restored by setting the [-t|--ttl-id] parameter.
+- `-d` will enable debugging output.
+- `-f` will fork the application to the background and create a pid file
+  at /var/run/udpbroadcastrelay_ID.pid
+- `-h|--help` Display a detailed help dialog.
 
 EXAMPLE
 -------
@@ -52,7 +69,7 @@ EXAMPLE
 
 (Chromecast requires broadcasts to originate from an address on its subnet)
 
-#### SSDP (Roku Discovery + More)
+#### SSDP (Roku Discovery, DLNA Media, Sonos, UPnP + More)
 `./udpbroadcastrelay --id 1 --port 1900 --dev eth0 --dev eth1 --multicast 239.255.255.250`
 
 #### Lifx Bulb Discovery
@@ -63,6 +80,25 @@ EXAMPLE
 
 #### Warcraft 3 Server Discovery
 `./udpbroadcastrelay --id 1 --port 6112 --dev eth0 --dev eth1`
+
+#### Windows Network Neighborhood Discovery
+ NetBIOS Name Service (137), SMB Browser (138) and SSDP (1900).
+ Windows Network Discovery across networks relies on relaying
+ these three protocols all at once.
+ To requires that three separate instances of udpbroadcastrelay
+ run simultaneously so in this example we execute the command
+ with the "-f" parameter in order to run the tool in the
+ background.
+`./udpbroadcastrelay --id 1 --port 137 --dev eth0 --dev eth1 -f`
+`./udpbroadcastrelay --id 2 --port 138 --dev eth0 --dev eth1 -f`
+`./udpbroadcastrelay --id 3 --port 1900 --dev eth0 --dev eth1 --multicast 239.255.255.250 -f`
+
+#### Syncthing Discovery
+`./udpbroadcastrelay --id 1 --port 21027 --dev eth0 --dev eth1`
+
+#### Raknet Discovery (Minecraft)
+`./udpbroadcastrelay --id 1 --port 19132 --dev eth0 --dev eth1`
+
 
 Note about firewall rules
 ---

--- a/net/udpbroadcastrelay/main.c
+++ b/net/udpbroadcastrelay/main.c
@@ -1,0 +1,806 @@
+/*
+******************************************************************
+udp-broadcast-relay-redux
+    Relays UDP broadcasts to other networks, forging
+    the sender address.
+
+Copyright (c) 2017 Michael Morrison <github.com/sonicsnes>
+Copyright (c) 2003 Joachim Breitner <mail@joachim-breitner.de>
+Copyright (C) 2002 Nathan O'Sullivan
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+******************************************************************
+*/
+
+#define MAXIFS    256
+#define MAXMULTICAST 256
+/*
+ * MAXID used to be 99 when TTL was marked with the ID but
+ * now that DSCP is used it needs to be limited to 6 bits.
+ */
+#define MAXID   63
+#define DPRINT  if (debug) printf
+#define IPHEADER_LEN 20
+#define UDPHEADER_LEN 8
+#define HEADER_LEN (IPHEADER_LEN + UDPHEADER_LEN)
+#define TTL_ID_OFFSET 64
+#define SIGF_TERM 0x1
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in_systm.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <netinet/udp.h>
+#include <errno.h>
+#include <string.h>
+#include <arpa/inet.h>
+#include <stdio.h>
+#ifdef __FreeBSD__
+#include <net/if.h>
+#include <net/if_dl.h>
+#else
+#include <linux/if.h>
+#endif
+#include <sys/ioctl.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <signal.h>
+
+
+
+static int exit_ok = 0;
+static sig_atomic_t sig_flags = 0;
+static char g_pidfile[128];
+
+/* list of addresses and interface numbers on local machine */
+struct Iface {
+    struct in_addr dstaddr;
+    struct in_addr ifaddr;
+    int ifindex;
+    int raw_socket;
+};
+static struct Iface ifs[MAXIFS];
+
+/* Where we forge our packets */
+static u_char gram[4096]=
+{
+    0x45,    0x00,    0x00,    0x26,
+    0x12,    0x34,    0x00,    0x00,
+    0xFF,    0x11,    0,    0,
+    0,    0,    0,    0,
+    0,    0,    0,    0,
+    0,    0,    0,    0,
+    0x00,    0x12,    0x00,    0x00,
+    '1','2','3','4','5','6','7','8','9','0'
+};
+
+void inet_ntoa2(struct in_addr in, char* chr, int len) {
+    char* from = inet_ntoa(in);
+    strncpy(chr, from, len);
+}
+
+void sig_term_handler(int signum, siginfo_t *info, void *ptr)
+{
+    unlink(g_pidfile);
+    exit(0);
+}
+
+void catch_sigterm()
+{
+    static struct sigaction _sigact;
+
+    memset(&_sigact, 0, sizeof(_sigact));
+    _sigact.sa_sigaction = sig_term_handler;
+    _sigact.sa_flags = SA_SIGINFO;
+
+    sigaction(SIGTERM, &_sigact, NULL);
+}
+
+void display_usage(FILE *stream, const char *arg0) {
+    fprintf(stream, "usage: %s [--id ID] [--port udp-port]\n"
+	    "       [--dev dev1] [--dev dev2] [--dev devX]\n"
+	    "       [-s IP] [--multicast ip1] [--multicast ipX]\n"
+            "       [-t|--ttl-id] [-d] [-f]\n"
+	    "       [-h|--help]\n", arg0);
+}
+
+void display_help(const char *arg0) {
+    printf("This program listens for packets on a specified UDP broadcast\n"
+	   "port. When a packet is received, it sends that packet to all\n"
+	   "specified interfaces but the one it came from as though it\n"
+	   "originated from the original sender.\n"
+	   "The primary purpose of this is to allow devices or game servers\n"
+	   "on separated local networks (Ethernet, WLAN, VLAN) that use udp\n"
+	   "broadcasts to find each other to do so.\n");
+    printf("Required Parameters:\n"
+	   "  --id ID  Set a unique ID for this instance of the tool.\n"
+	   "           Valid range 1 - %i. The IP DSCP field of a relayed\n"
+	   "           packet is set to this value so the tool may\n"
+	   "           identify and drop already relayed packets in order\n"
+	   "           to avoid packet storms.\n"
+	   "  --port udp-port   Destination UDP port to listen for.\n"
+	   "                    Valid range 1 - 65535.\n"
+	   "                    e.g.  5353 - mDNS/Chromecast/Apple Bonjour\n"
+	   "                          1900 - UPnP Discovery/SSDP\n"
+	   "                          37 - NetBIOS name service (Windows)\n"
+	   "                          38 - SMB Browser (Windows)\n"
+	   "                    Only specify one udp-port per instance.\n"
+	   "  --dev device   Name of an interface to listen for and to \n"
+	   "                 relay packets to. This option must be specified\n"
+	   "                 at least twice for two separate interfaces in\n"
+	   "                 order for this tool to have any effect.\n", MAXID);
+    printf("Optional Parameters:\n"
+	   "  -s IP    Sets the source IP of forwarded packets. If not\n"
+	   "           specified the original IP source address is used.\n"
+	   "           Special values :\n"
+	   "           1.1.1.1 - Use the outgoing interface ip address as\n"
+	   "                     source IP. Also forces the outgoing packet\n"
+	   "                     source UDP port to the same as the destination\n"
+	   "                     UDP port.\n"
+	   "           1.1.1.2 - Use the outgoing interface ip address as \n"
+	   "                     source IP. Does not modify UDP ports.\n"
+	   "           These special values help in rare cases e.g. Chromecast\n"
+	   "  --multicast IP   As well as listening for broadcasts the program\n"
+	   "                   will listen for and relay multicast packets\n"
+	   "                   using the specified multicast IP address(es).\n"
+	   "                   e.g. 224.0.0.251 - mDNS/Chromecast/Apple Bonjour\n"
+	   "                        239.255.255.250 - UPnP Discovery/SSDP\n"
+	   "                   This argument may be specified more than once.\n"
+	   "  --ttl-id|-t   Preserve DSCP and mark relayed packets by setting\n"
+	   "                the IP TTL header field to ID + %i. This is how the\n"
+	   "                original version of this tool operated by default.\n"
+	   "  -d       Enables debugging.\n"
+	   "  -f       Forces forking to background. A PID file will be created\n"
+	   "           at /var/run/udpbroadcastrelay_ID.pid\n"
+	   "  --help|-h   Display this detailed help dialog.\n", TTL_ID_OFFSET);
+}
+
+int main(int argc,char **argv) {
+    /* Debugging, forking, other settings */
+    FILE *pidfp;
+    int debug = 0, forking = 0, pid;
+    int use_ttl_id = 0;
+    u_int16_t port = 0;
+    u_char id = 0;
+    char *usr_pid = 0;
+    char* multicastAddrs[MAXMULTICAST];
+    int multicastAddrsNum = 0;
+    char* interfaceNames[MAXIFS];
+    int interfaceNamesNum = 0;
+    in_addr_t spoof_addr = 0;
+
+    /* Address broadcast packet was sent from */
+    struct sockaddr_in rcv_addr;
+    struct msghdr rcv_msg;
+    struct iovec iov;
+    iov.iov_base = gram + HEADER_LEN;
+    iov.iov_len = 4006 - HEADER_LEN - 1;
+    u_char pkt_infos[16384];
+    rcv_msg.msg_name = &rcv_addr;
+    rcv_msg.msg_namelen = sizeof(rcv_addr);
+    rcv_msg.msg_iov = &iov;
+    rcv_msg.msg_iovlen = 1;
+    rcv_msg.msg_control = pkt_infos;
+    rcv_msg.msg_controllen = sizeof(pkt_infos);
+    static char pidfile[128];
+   
+    int child_pid;
+#ifndef HAVE_ARC4RANDOM
+srandom(time(NULL) & getpid());
+#endif
+
+
+
+    if(argc < 2) {
+	display_usage(stderr, argv[0]);
+	exit(1);
+    }
+
+    int i;
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i],"-d") == 0) {
+            DPRINT ("Debugging Mode enabled\n");
+            debug = 1;
+        }
+	if ((strcmp(argv[i], "--help") == 0) ||
+	    (strcmp(argv[i], "-h") == 0)) {
+	    display_usage(stdout, argv[0]);
+	    display_help(argv[0]);
+	    exit(0);
+	}
+    }
+
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i],"-d") == 0) {
+            // Already handled
+        } else if (strcmp(argv[i],"-f") == 0) {
+            DPRINT ("Forking Mode enabled\n");
+            forking = 1;
+        }
+        else if (strcmp(argv[i],"-s") == 0) {
+            /* INADDR_NONE is a valid IP address (-1 = 255.255.255.255),
+             * so inet_pton() would be a better choice. But in this case it
+             * does not matter. */
+            i++;
+            spoof_addr = inet_addr(argv[i]);
+            if (spoof_addr == INADDR_NONE) {
+                fprintf (stderr,"invalid IP address: %s\n", argv[i]);
+                exit(1);
+            }
+            DPRINT ("Outgoing source IP set to %s\n", argv[i]);
+        }
+        else if (strcmp(argv[i],"--id") == 0) {
+            i++;
+            id = atoi(argv[i]);
+            DPRINT ("ID set to %i\n", id);
+        }
+        else if (strcmp(argv[i],"--port") == 0) {
+            i++;
+            port = atoi(argv[i]);
+            DPRINT ("Port set to %i\n", port);
+        }
+        else if (strcmp(argv[i],"--dev") == 0) {
+	    if (interfaceNamesNum >= MAXIFS) {
+		fprintf(stderr, "More than %i interfaces specified.\n", MAXIFS);
+		exit(1);
+	    }
+            i++;
+            interfaceNames[interfaceNamesNum] = argv[i];
+            interfaceNamesNum++;
+        }
+        else if (strcmp(argv[i],"--pid") == 0) {
+            i++;
+            usr_pid = argv[i];            
+        }
+        else if (strcmp(argv[i],"--multicast") == 0) {
+	    if (multicastAddrsNum >= MAXMULTICAST) {
+		fprintf(stderr, "More than %i multicast addresses specified", MAXMULTICAST);
+		exit(1);
+	    }
+            i++;
+            multicastAddrs[multicastAddrsNum] = argv[i];
+            multicastAddrsNum++;
+        }
+	else if ((strcmp(argv[i], "--ttl-id") == 0) ||
+		 (strcmp(argv[i], "-t") == 0)) {
+	    use_ttl_id = 1;
+	}
+        else if (strncmp(argv[i], "-", 1) == 0) {
+            fprintf (stderr, "Unknown arg: %s\n", argv[i]);
+            exit(1);
+        }
+        else {
+            break;
+        }
+    }
+
+    if (id < 1 || id > MAXID)
+    {
+        fprintf (stderr,"ID argument %i not between 1 and %i\n", id, MAXID);
+        exit(1);
+    }
+    if (port < 1 || port > 65535) {
+        fprintf (stderr,"Port argument not valid\n");
+        exit(1);
+    }
+
+
+	
+    
+    u_char ttl = 0;
+    u_char tos = 0;
+    if (use_ttl_id) {
+	ttl = id + TTL_ID_OFFSET;
+	DPRINT ("ID: %i (ttl: %i), Port %i\n",id,ttl,port);
+    } else {
+	/*
+	 * DSCP occupies the most significant 6 bits of the IP
+	 * TOS field. We do not use the remaining 2 bits (ECN)
+	 * because there are reports that in rare cases hosts
+	 * can react poorly to these being set spuriously.
+	 */
+	tos = id << 2;
+	DPRINT ("ID: %i (DSCP: %i, ToS: 0x%02x), Port %i\n", id, id,
+		tos, port);
+    }
+
+
+
+    /* We need to find out what IP's are bound to this host - set up a temporary socket to do so */
+    int fd;
+     if((fd=socket(AF_INET,SOCK_RAW,IPPROTO_RAW)) < 0)
+    {
+          perror("socket");
+        fprintf(stderr,"You must be root to create a raw socket\n");
+          exit(1);
+      };
+
+
+    /* For each interface on the command line */
+    int maxifs = 0;
+    for (int i = 0; i < interfaceNamesNum; i++) {
+        struct Iface* iface = &ifs[maxifs];
+
+        struct ifreq basereq;
+        strncpy(basereq.ifr_name,interfaceNames[i],IFNAMSIZ);
+
+        /* Request index for this interface */
+        {
+            #ifdef ___APPLE__
+                /*
+                TODO: Supposedly this works for all OS, including non-Apple, 
+                and could replace the code below
+                */
+                iface->ifindex = if_nametoindex(interfaceNames[i]);
+            #else
+                struct ifreq req;
+                memcpy(&req, &basereq, sizeof(req));
+                if (ioctl(fd,SIOCGIFINDEX, &req) < 0) {
+                    perror("ioctl(SIOCGIFINDEX)");
+                    exit(1);
+                }
+                #ifdef __FreeBSD__
+                iface->ifindex = req.ifr_index;
+                #else
+                iface->ifindex = req.ifr_ifindex;
+                #endif
+            #endif
+        }
+
+        /* Request flags for this interface */
+        short ifFlags;
+        {
+            struct ifreq req;
+            memcpy(&req, &basereq, sizeof(req));
+            if (ioctl(fd,SIOCGIFFLAGS, &req) < 0) {
+                perror("ioctl(SIOCGIFFLAGS)");
+                exit(1);
+            }
+            ifFlags = req.ifr_flags;
+        }
+
+        /* if the interface is not up or a loopback, ignore it */
+        if ((ifFlags & IFF_UP) == 0 || (ifFlags & IFF_LOOPBACK)) {
+            continue;
+        }
+
+        /* Get local IP for interface */
+        {
+            struct ifreq req;
+            memcpy(&req, &basereq, sizeof(req));
+            if (ioctl(fd,SIOCGIFADDR, &req) < 0) {
+                perror("ioctl(SIOCGIFADDR)");
+                exit(1);
+            }
+            memcpy(
+                &iface->ifaddr,
+                &((struct sockaddr_in *)&req.ifr_addr)->sin_addr,
+                sizeof(struct in_addr)
+            );
+        }
+
+        /* Get broadcast address for interface */
+        {
+            struct ifreq req;
+            memcpy(&req, &basereq, sizeof(req));
+            if (ifFlags & IFF_BROADCAST) {
+                if (ioctl(fd,SIOCGIFBRDADDR, &req) < 0) {
+                    perror("ioctl(SIOCGIFBRDADDR)");
+                    exit(1);
+                }
+                memcpy(
+                    &iface->dstaddr,
+                    &((struct sockaddr_in *)&req.ifr_broadaddr)->sin_addr,
+                    sizeof(struct in_addr)
+                );
+            } else {
+                if (ioctl(fd,SIOCGIFDSTADDR, &req) < 0) {
+                    perror("ioctl(SIOCGIFBRDADDR)");
+                    exit(1);
+                }
+                memcpy(
+                    &iface->dstaddr,
+                    &((struct sockaddr_in *)&req.ifr_dstaddr)->sin_addr,
+                    sizeof(struct in_addr)
+                );
+            }
+        }
+
+        char ifaddr[255];
+        inet_ntoa2(iface->ifaddr, ifaddr, sizeof(ifaddr));
+        char dstaddr[255];
+        inet_ntoa2(iface->dstaddr, dstaddr, sizeof(dstaddr));
+
+        DPRINT(
+            "%s: %i / %s / %s\n",
+            basereq.ifr_name,
+            iface->ifindex,
+            ifaddr,
+            dstaddr
+        );
+
+        // Set up a one raw socket per interface for sending our packets through
+        if((iface->raw_socket = socket(AF_INET,SOCK_RAW,IPPROTO_RAW)) < 0) {
+            perror("socket");
+            exit(1);
+        }
+        {
+            int yes = 1;
+            int no = 0;
+            if (setsockopt(iface->raw_socket, SOL_SOCKET, SO_BROADCAST, &yes, sizeof(yes))<0) {
+                perror("setsockopt SO_BROADCAST");
+                exit(1);
+            }
+            if (setsockopt(iface->raw_socket, IPPROTO_IP, IP_HDRINCL, &yes, sizeof(yes))<0) {
+                perror("setsockopt IP_HDRINCL");
+                exit(1);
+            }
+            if (setsockopt(iface->raw_socket, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes))<0) {
+                perror("setsockopt SO_REUSEPORT");
+                exit(1);
+            }
+            #ifdef __FreeBSD__
+                if((setsockopt(iface->raw_socket, IPPROTO_IP, IP_MULTICAST_LOOP, &no, sizeof(no))) < 0) {
+                    perror("setsockopt IP_MULTICAST_LOOP");
+                }
+                if((setsockopt(iface->raw_socket, IPPROTO_IP, IP_MULTICAST_IF, &iface->ifaddr, sizeof(iface->ifaddr))) < 0) {
+                    perror("setsockopt IP_MULTICAST_IF");
+                }
+		if (use_ttl_id) {
+		    int setttl = ttl;
+		    if((setsockopt(iface->raw_socket, IPPROTO_IP, IP_MULTICAST_TTL, &setttl, sizeof(setttl))) < 0) {
+			perror("setsockopt IP_MULTICAST_TTL");
+		    }
+		}
+            #else
+                // bind socket to dedicated NIC (override routing table)
+                if (setsockopt(iface->raw_socket, SOL_SOCKET, SO_BINDTODEVICE, interfaceNames[i], strlen(interfaceNames[i])+1)<0)
+                {
+                    perror("setsockopt SO_BINDTODEVICE");
+                    exit(1);
+                };
+            #endif
+        }
+
+        /* ... and count it */
+        maxifs++;
+    }
+
+    DPRINT("found %i interfaces total\n",maxifs);
+
+    /* Free our allocated buffer and close the socket */
+    close(fd);
+
+    /* Create our broadcast receiving socket */
+    int rcv;
+    {
+        if((rcv=socket(AF_INET,SOCK_DGRAM,IPPROTO_UDP)) < 0)
+          {
+              perror("socket");
+              exit(1);
+          }
+        int yes = 1;
+        if(setsockopt(rcv, SOL_SOCKET, SO_BROADCAST, &yes, sizeof(yes))<0){
+            perror("SO_BROADCAST on rcv");
+            exit(1);
+        };
+        if (setsockopt(rcv, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes))<0) {
+            perror("SO_REUSEPORT on rcv");
+            exit(1);
+        }
+        #ifdef __FreeBSD__
+            if(setsockopt(rcv, IPPROTO_IP, IP_RECVTTL, &yes, sizeof(yes))<0){
+                perror("IP_RECVTTL on rcv");
+                exit(1);
+            };
+	    if(setsockopt(rcv, IPPROTO_IP, IP_RECVTOS, &yes, sizeof(yes))<0){
+		perror("IP_RECVTOS on rcv");
+		exit(1);
+	    };
+            if(setsockopt(rcv, IPPROTO_IP, IP_RECVIF, &yes, sizeof(yes))<0){
+                perror("IP_RECVIF on rcv");
+                exit(1);
+            };
+            if(setsockopt(rcv, IPPROTO_IP, IP_RECVDSTADDR, &yes, sizeof(yes))<0){
+                perror("IP_RECVDSTADDR on rcv");
+                exit(1);
+            };
+        #else
+            if(setsockopt(rcv, SOL_IP, IP_RECVTTL, &yes, sizeof(yes))<0){
+                perror("IP_RECVTTL on rcv");
+                exit(1);
+            };
+	    if(setsockopt(rcv, SOL_IP, IP_RECVTOS, &yes, sizeof(yes))<0){
+		perror("IP_RECVTOS on rcv");
+		exit(1);
+	    };
+            if(setsockopt(rcv, SOL_IP, IP_PKTINFO, &yes, sizeof(yes))<0){
+                perror("IP_PKTINFO on rcv");
+                exit(1);
+            };
+        #endif
+        for (int i = 0; i < multicastAddrsNum; i++) {
+            for (int x = 0; x < maxifs; x++) {
+                struct ip_mreq mreq;
+                memset(&mreq, 0, sizeof(struct ip_mreq));
+                mreq.imr_interface.s_addr = ifs[x].ifaddr.s_addr;
+                mreq.imr_multiaddr.s_addr = inet_addr(multicastAddrs[i]);
+                DPRINT("IP_ADD_MEMBERSHIP:\t\t%s %s\n",inet_ntoa(ifs[x].ifaddr),multicastAddrs[i]);
+                if(setsockopt(rcv, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq))<0){
+                    perror("IP_ADD_MEMBERSHIP on rcv");
+                    exit(1);
+                }
+            }
+        }
+
+        struct sockaddr_in bind_addr;
+        bind_addr.sin_family = AF_INET;
+        bind_addr.sin_port = htons(port);
+        bind_addr.sin_addr.s_addr = INADDR_ANY;
+        if(bind(rcv, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) < 0) {
+            perror("bind");
+            fprintf(stderr,"rcv bind\n");
+            exit(1);
+        }
+    }
+
+
+    DPRINT("Done Initializing\n\n");
+    sprintf(pidfile,"/var/run/udpbroadcastrelay_%d.pid",id);
+    if ((pidfp = fopen(pidfile, "w")) != NULL) {                 
+    fprintf(pidfp, "%d\n", child_pid);
+    fclose(pidfp);
+    strcpy(g_pidfile,pidfile);
+    }     
+    /* Fork to background */
+    if (! debug) {
+        if (forking && (child_pid=fork())) {
+            sprintf(pidfile,"/var/run/udpbroadcastrelay_%d.pid",id);
+            if ((pidfp = fopen(pidfile, "w")) != NULL) {                 
+            fprintf(pidfp, "%d\n", child_pid);
+            fclose(pidfp);
+            strcpy(g_pidfile,pidfile);
+            }
+        
+        exit(0);
+        fclose(stdin);
+        fclose(stdout);
+        fclose(stderr);
+        }
+    }
+    
+
+    for (;;) /* endless loop */
+    {
+        
+        catch_sigterm();
+        /* Receive a broadcast packet */
+        int len = recvmsg(rcv,&rcv_msg,0);
+        if (len <= 0) continue;    /* ignore broken packets */
+
+        /* Find the ToS, ttl and the receiving interface */
+        struct cmsghdr *cmsg;
+        int rcv_ttl = 0;
+	int rcv_tos = 0;
+	int found_rcv_tos = 0;
+        int rcv_ifindex = 0;
+        struct in_addr rcv_inaddr;
+        int foundRcvIf = 0;
+        int foundRcvIp = 0;
+        if (rcv_msg.msg_controllen > 0) {
+            for (cmsg=CMSG_FIRSTHDR(&rcv_msg);cmsg;cmsg=CMSG_NXTHDR(&rcv_msg,cmsg)) {
+                #ifdef __FreeBSD__
+                    if (cmsg->cmsg_type==IP_RECVTTL) {
+                        rcv_ttl = *(int *)CMSG_DATA(cmsg);
+                    }
+		    if (cmsg->cmsg_type==IP_RECVTOS) {
+			rcv_tos = *(int *)CMSG_DATA(cmsg);
+			found_rcv_tos = 1;
+		    }
+                    if (cmsg->cmsg_type==IP_RECVDSTADDR) {
+                        rcv_inaddr=*((struct in_addr *)CMSG_DATA(cmsg));
+                        foundRcvIp = 1;
+                    }
+                    if (cmsg->cmsg_type==IP_RECVIF) {
+                        rcv_ifindex=((struct sockaddr_dl *)CMSG_DATA(cmsg))->sdl_index;
+                        foundRcvIf = 1;
+                    }
+                #else
+                    if (cmsg->cmsg_type==IP_TTL) {
+                        rcv_ttl = *(int *)CMSG_DATA(cmsg);
+                    }
+		    if (cmsg->cmsg_type==IP_TOS) {
+			rcv_tos = *(int *)CMSG_DATA(cmsg);
+			found_rcv_tos = 1;
+		    }
+                    if (cmsg->cmsg_type==IP_PKTINFO) {
+                        rcv_ifindex=((struct in_pktinfo *)CMSG_DATA(cmsg))->ipi_ifindex;
+                        foundRcvIf = 1;
+                        rcv_inaddr=((struct in_pktinfo *)CMSG_DATA(cmsg))->ipi_addr;
+                        foundRcvIp = 1;
+                    }
+                #endif
+            }
+        }
+
+        if (!foundRcvIp) {
+            perror("Source IP not found on incoming packet\n");
+            continue;
+        }
+        if (!foundRcvIf) {
+            perror("Interface not found on incoming packet\n");
+            continue;
+        }
+        if (!rcv_ttl) {
+            perror("TTL not found on incoming packet\n");
+            continue;
+        }
+	if (!found_rcv_tos) {
+	    if (use_ttl_id) {
+		/*
+		 * If we're not using DSCP as the tag field then
+		 * this error doesn't matter but print the warning
+		 * anyway.
+		 */
+		perror("Warning : ToS not found on incoming packet - continuing processing\n");
+	    } else {
+		perror("ToS not found on incoming packet\n");
+		continue;
+	    }
+	}
+
+        struct Iface* fromIface = NULL;
+        for (int iIf = 0; iIf < maxifs; iIf++) {
+            if (ifs[iIf].ifindex == rcv_ifindex) {
+                fromIface = &ifs[iIf];
+            }
+        }
+
+        struct in_addr origFromAddress = rcv_addr.sin_addr;
+        u_short origFromPort = ntohs(rcv_addr.sin_port);
+        struct in_addr origToAddress = rcv_inaddr;
+        u_short origToPort = port;
+
+        gram[HEADER_LEN + len] = 0;
+
+        char origFromAddressStr[255];
+        inet_ntoa2(origFromAddress, origFromAddressStr, sizeof(origFromAddressStr));
+        char origToAddressStr[255];
+        inet_ntoa2(origToAddress, origToAddressStr, sizeof(origToAddressStr));
+        DPRINT("<- [ %s:%d -> %s:%d (iface=%d len=%i tos=0x%02x DSCP=%i ttl=%i)\n",
+            origFromAddressStr, origFromPort,
+            origToAddressStr, origToPort,
+	    rcv_ifindex, len, rcv_tos,
+	    rcv_tos >> 2, rcv_ttl
+        );
+
+	if (use_ttl_id) {
+	    if (rcv_ttl == ttl) {
+		DPRINT("IP TTL (%i) matches ID (%i) + %i. Packet Ignored.\n\n",
+		       rcv_ttl, id, TTL_ID_OFFSET);
+		continue;
+	    }
+        } else {
+	    if ((rcv_tos & 0xfc) == tos) {
+		DPRINT("IP DSCP (%i) matches ID. IP ToS 0x%2x. Packet Ignored.\n\n",
+		       tos >> 2, tos);
+		continue;
+	    }
+	}
+        if (!fromIface) {
+            DPRINT("Not from managed iface\n\n");
+            continue;
+        }
+
+        /* Iterate through our interfaces and send packet to each one */
+        for (int iIf = 0; iIf < maxifs; iIf++) {
+            struct Iface* iface = &ifs[iIf];
+
+            /* no bounces, please */
+            if (iface == fromIface) {
+                continue;
+            }
+
+            struct in_addr fromAddress;
+            u_short fromPort;
+            if (spoof_addr == inet_addr("1.1.1.1")) {
+                fromAddress = iface->ifaddr;
+                fromPort = port;
+            } else if (spoof_addr == inet_addr("1.1.1.2")) {
+                fromAddress = iface->ifaddr;
+                fromPort = origFromPort;
+            } else if (spoof_addr) {
+                fromAddress.s_addr = spoof_addr;
+                fromPort = origFromPort;
+            } else {
+                fromAddress = origFromAddress;
+                fromPort = origFromPort;
+            }
+
+            struct in_addr toAddress;
+            if (rcv_inaddr.s_addr == INADDR_BROADCAST
+                || rcv_inaddr.s_addr == fromIface->dstaddr.s_addr) {
+                // Received on interface broadcast address -- rewrite to new interface broadcast addr
+                toAddress = iface->dstaddr;
+            } else {
+                // Send to whatever IP it was originally to
+                toAddress = rcv_inaddr;
+            }
+            u_short toPort = origToPort;
+
+            char fromAddressStr[255];
+            inet_ntoa2(fromAddress, fromAddressStr, sizeof(fromAddressStr));
+            char toAddressStr[255];
+            inet_ntoa2(toAddress, toAddressStr, sizeof(toAddressStr));
+            DPRINT (
+                "-> [ %s:%d -> %s:%d (iface=%d len=%i ",
+                fromAddressStr, fromPort,
+                toAddressStr, toPort,
+                iface->ifindex, len);
+	    if (use_ttl_id) {
+		DPRINT("tos=0x%02x DSCP=%i ttl=%i)\n",
+		       rcv_tos, rcv_tos >> 2, ttl);
+	    } else {
+		DPRINT("tos=0x%02x DSCP=%i ttl=%i)\n",
+		       tos + (rcv_tos & 0x03), tos >> 2, rcv_ttl);
+	    }
+            /* Send the packet */
+
+	    if (use_ttl_id) {
+		/* Set IP TTL field */
+		/* Note. The following statement has no effect on
+		 * multicast packets, only on relayed broadcasts.
+		 * For mcast packets we have to set socket
+		 * option IP_MULTICAST_TTL to change TTL */
+		gram[8] = ttl;
+	    } else {
+		/*
+		 * Set IP ToS byte so that DSCP = instance ID and ECN is
+		 * preserved from the original packet.
+		 */
+		gram[1] = tos + (rcv_tos & 0x03);
+		/* Set TTL to the same as the received packet */
+		gram[8] = rcv_ttl;
+		if((setsockopt(iface->raw_socket, IPPROTO_IP, IP_MULTICAST_TTL, &rcv_ttl, sizeof(rcv_ttl))) < 0) {
+		    perror("setsockopt IP_MULTICAST_TTL");
+		}
+	    }
+            memcpy(gram+12, &fromAddress.s_addr, 4);
+            memcpy(gram+16, &toAddress.s_addr, 4);
+            *(u_short*)(gram+20)=htons(fromPort);
+            *(u_short*)(gram+22)=htons(toPort);
+            #if (defined __FreeBSD__ && __FreeBSD__ <= 10) || defined __APPLE__
+            *(u_short*)(gram+24)=htons(UDPHEADER_LEN + len);
+            *(u_short*)(gram+2)=HEADER_LEN + len;
+            #else
+            *(u_short*)(gram+24)=htons(UDPHEADER_LEN + len);
+            *(u_short*)(gram+2)=htons(HEADER_LEN + len);
+            #endif
+            struct sockaddr_in sendAddr;
+            sendAddr.sin_family = AF_INET;
+            sendAddr.sin_port = htons(toPort);
+            sendAddr.sin_addr = toAddress;
+
+            if (sendto(
+                iface->raw_socket,
+                &gram,
+                HEADER_LEN+len,
+                0,
+                (struct sockaddr*)&sendAddr,
+                sizeof(sendAddr)
+            ) < 0) {
+                perror("sendto");
+            }
+        }
+        DPRINT ("\n");
+    }
+}

--- a/net/udpbroadcastrelay/pkg-descr
+++ b/net/udpbroadcastrelay/pkg-descr
@@ -1,0 +1,29 @@
+udbproadcastrelay is a USB multicast relayer. Its intended use is to
+rebroadbcast udp packets on a specific port across interfaces, be those
+interfaces physical or VLAN. 
+
+It is used where devices such as Sonos or Sky are spread accross 
+different subnets and are not able to detect the servers or devices.
+
+Examples of different devices and the ports are as follows:
+
+Syncthing discovery 
+udp_vars="--id 1 --port 21027 --dev igb1 --dev igb2"
+
+mDNS / Broadcast DNS (Chromecast Discovery + Bonjour + More)
+udp_vars="--id 1 --port 5353 --dev eth0 --dev eth1 --multicast 224.0.0.251 -s 1.1.1.1"
+
+(Chromecast requires broadcasts to originate from an address on its subnet) use
+the rebroadbcast address option.
+
+SSDP (Sonos Roku Discovery + More)
+udp_vars="--id 1 --port 1900 --dev eth0 --dev eth1 --multicast 239.255.255.250"
+
+Lifx Bulb Discovery
+udp_vars=" --id 1 --port 56700 --dev eth0 --dev eth1"
+
+Broadlink IR Emitter Discovery
+udp_vars=" --id 1 --port 80 --dev eth0 --dev eth1"
+
+Warcraft 3 Server Discovery
+udp_vars=" --id 1 --port 6112 --dev eth0 --dev eth1"

--- a/net/udpbroadcastrelay/usage-notes/OPNsense-config/udpbroadcastrelay.conf
+++ b/net/udpbroadcastrelay/usage-notes/OPNsense-config/udpbroadcastrelay.conf
@@ -1,0 +1,5 @@
+# change the port and add --dev {dev-name} as many times as needed.
+udpbroadcastrelay_enable="YES"
+udpbroadcastrelay_1=" --id 1 --dev igb2 --dev igb3 --port 1900 --multicast 239.255.255.250 -f"
+udpbroadcastrelay_instances=" 1"
+ 

--- a/net/udpbroadcastrelay/usage-notes/OPNsense-config/udpbroadcastrelay.sh
+++ b/net/udpbroadcastrelay/usage-notes/OPNsense-config/udpbroadcastrelay.sh
@@ -1,0 +1,173 @@
+#!/bin/sh
+#
+# $FreeBSD$
+#
+
+# PROVIDE: udpbroadcastrelay
+# KEYWORD: shutdown
+
+. /etc/rc.subr
+
+name="udpbroadcastrelay"
+rcvar="udpbroadcastrelay_enable"
+command="/usr/local/sbin/udpbroadcastrelay"
+extra_commands="reload"
+reload_cmd="udpbroadcastrelay_reload"
+load_rc_config "udpbroadcastrelay.conf"
+
+
+if [ -n "$2" ]; then
+   eval udpbroadcastrelay_flags=\$udpbroadcastrelay_${2}
+   pidfile="/var/run/udpbroadcastrelay_$2.pid"
+fi
+
+
+udpbroadcastrelay_start () {
+   udpbroadcastrelay_status
+   if [ $? -eq 0 ]; then # already running
+      return 0
+   fi
+   run_rc_command "start"
+   if [ $? -eq 0 ]; then
+      cmd_string=`basename ${procname:-${command}}`
+
+      ps_pid=`ps ax -o pid= -o command= | grep $cmd_string | grep -e "$udpbroadcastrelay_flags" | grep -v grep | awk '{ print $1 }'`
+      if [ -z "$ps_pid" ]; then
+         err 1 "Cannot get pid for $cmd_string $udpbroadcastrelay_flags"
+      fi
+      return $?
+   fi
+   return 1
+}
+
+udpbroadcastrelay_stop () {
+   udpbroadcastrelay_status
+   if [ $? -eq 1 ]; then # already stopped
+      return 0
+   fi
+   run_rc_command "stop"
+   if [ $? -ne 0 ]; then
+      err 1 "Cannot stop udpbroadcastrelay with pid from $pidfile"
+   fi
+   rm -f $pidfile
+   return $?
+}
+
+udpbroadcastrelay_restart () {
+   udpbroadcastrelay_stop
+   if [ $? -ne 0 ]; then
+      return $?
+   fi
+   udpbroadcastrelay_start
+   return $?
+}
+
+udpbroadcastrelay_status () {
+   if [ -z "$pidfile" ]; then
+      err 1 "Instance name unknown"
+   fi
+   run_rc_command "status"
+   return $?
+}
+
+udpbroadcastrelay_reload () {
+   
+   echo "In Reload" >> "/tmp/udr.log"
+   udpbroadcastrelay_flags=""
+   pidfile=""
+   # get running instances
+   ps ax -o pid= -o command= | grep "udpbroadcastrelay" | grep -v grep | while read line; do
+      # get instance name
+      instance=`echo $line | awk '{printf "%s", $4 }' | sed 's/\./_/g'`
+      # get instance flags
+      instance_flags="${line#*udpbroadcastrelay}"
+      # check if it should run
+      echo 
+      eval udpbroadcastrelay_flags=\$udpbroadcastrelay_${instance}
+
+      if [ -n "$udpbroadcastrelay_flags" -a "$udpbroadcastrelay_flags" = "$instance_flags" ]; then
+         echo "running instance $instance match config"
+         continue
+      fi
+      echo "running instance $instance not configured"
+      udpbroadcastrelay_flags=$instance_flags
+      pidfile="/var/run/udpbroadcastrelay_$instance.pid"
+      udpbroadcastrelay_stop
+   done
+   # start configured instances
+  
+   if [ -n "$udpbroadcastrelay_instances" ]; then
+ 
+      for i in $udpbroadcastrelay_instances; do
+         eval udpbroadcastrelay_flags=\$udpbroadcastrelay_${i}
+         pidfile="/var/run/udpbroadcastrelay_$i.pid"
+         run_rc_command "start"
+      done
+   fi
+   return 0
+}
+
+case $1 in
+   start)
+    
+      if [ -z "$udpbroadcastrelay_flags=\$udpbroadcastrelay_${i}" -o -z "$pidfile" ]; then
+         if [ -n "$udpbroadcastrelay_instances" ]; then
+            for i in $udpbroadcastrelay_instances; do
+               eval udpbroadcastrelay_flags=\$udpbroadcastrelay_${i}
+               pidfile="/var/run/udpbroadcastrelay_$i.pid"
+              
+               udpbroadcastrelay_start
+            done
+         fi
+      else
+         udpbroadcastrelay_start
+      fi
+      exit $?
+      ;;
+   stop)
+      if [ -z "$udpbroadcastrelay_flags" -o -z "$pidfile" ]; then
+         if [ -n "$udpbroadcastrelay_instances" ]; then
+            for i in $udpbroadcastrelay_instances; do
+               eval udpbroadcastrelay_flags=\$udpbroadcastrelay_${i}
+               pidfile="/var/run/udpbroadcastrelay_$i.pid"
+               udpbroadcastrelay_stop
+            done
+         fi
+      else
+         udpbroadcastrelay_stop
+      fi
+      exit $?
+      ;;
+   restart)
+      if [ -z "$udpbroadcastrelay_flags" -o -z "$pidfile" ]; then
+         if [ -n "$udpbroadcastrelay_instances" ]; then
+            for i in $udpbroadcastrelay_instances; do
+               eval udpbroadcastrelay_flags=\$udpbroadcastrelay_${i}
+               pidfile="/var/run/udpbroadcastrelay_$i.pid"
+               udpbroadcastrelay_restart
+            done
+         fi
+      else
+         udpbroadcastrelay_restart
+      fi
+      exit $?
+      ;;
+   status)
+      if [ -z "$udpbroadcastrelay_flags" -a -z "$pidfile" ]; then
+         if [ -n "$udpbroadcastrelay_instances" ]; then
+            for i in $udpbroadcastrelay_instances; do
+               eval udpbroadcastrelay_flags=\$udpbroadcastrelay_${i}
+               pidfile="/var/run/udpbroadcastrelay_$i.pid"
+               udpbroadcastrelay_status
+            done
+         fi
+      else
+         udpbroadcastrelay_status
+      fi
+      exit $?
+      ;;
+   reload)
+      udpbroadcastrelay_reload;
+      exit $?
+      ;;
+esac

--- a/net/udpbroadcastrelay/usage-notes/readme.md
+++ b/net/udpbroadcastrelay/usage-notes/readme.md
@@ -1,0 +1,2 @@
+All though this can be run manually, a plugin exists to control all aspects.
+It is advised to use the plugin.


### PR DESCRIPTION
udpbroadcastrelay. A daemon to handle forwarding of udp unicast and multicast packets between interfaces for use with Sonos, Sky, Chromecast and others.

This version varies from the original UDP-BROADCAST-RELAY-REDUX in that it now generates its own pid file when forking to the background, and should also clean up and delete the pid file after it exits, it does in all the tests I have carried out.