### PR TITLE
Updated Intel hyperscan to 5.2.1

### DIFF
--- a/devel/hyperscan/Makefile
+++ b/devel/hyperscan/Makefile
@@ -1,57 +1,57 @@
 # $FreeBSD$
 
-PORTNAME=	hyperscan
-PORTVERSION=	4.7.0
-PORTREVISION=	3
-DISTVERSIONPREFIX=	v
-CATEGORIES=	devel textproc
-MASTER_SITES=	SF/boost/boost/1.65.1:boost
-DISTFILES=	boost_1_65_1.tar.gz:boost
+PORTNAME=       hyperscan
+PORTVERSION=    5.2.1
+PORTREVISION=   4
+DISTVERSIONPREFIX=      v
+CATEGORIES=     devel textproc
+MASTER_SITES=   SF/boost/boost/1.73.0:boost
+DISTFILES=      boost_1_73_0.tar.bz2:boost
 
-MAINTAINER=	vsevolod@FreeBSD.org
-COMMENT=	High-performance multiple regex matching library
+MAINTAINER=     vsevolod@FreeBSD.org
+COMMENT=        High-performance multiple regex matching library
 
-LICENSE=	BSD3CLAUSE
+LICENSE=        BSD3CLAUSE
 
-BUILD_DEPENDS=	ragel:devel/ragel
+BUILD_DEPENDS=  ragel:devel/ragel
 
-USE_GITHUB=	yes
-GH_ACCOUNT=	intel
-USES=	compiler:c++11-lib cmake pathfix python:build
-ONLY_FOR_ARCHS=	amd64
-ONLY_FOR_ARCHS_REASON=	SSSE3 is required for work
+USE_GITHUB=     yes
+GH_ACCOUNT=     intel
+USES=   compiler:c++11-lib cmake pathfix python:build
+ONLY_FOR_ARCHS= amd64
+ONLY_FOR_ARCHS_REASON=  SSSE3 is required for work
 
-OPTIONS_DEFINE=	SHARED NATIVE
-SHARED_DESC=		Build shared library
-NATIVE_DESC=		Build with native CPU tunes
-OPTIONS_DEFAULT=	SHARED
+OPTIONS_DEFINE= SHARED NATIVE
+SHARED_DESC=            Build shared library
+NATIVE_DESC=            Build with native CPU tunes
+OPTIONS_DEFAULT=        SHARED
 
-CMAKE_ARGS+=	-DBOOST_ROOT=${WRKDIR}/boost_1_65_1
+CMAKE_ARGS+=    -DBOOST_ROOT=${WRKDIR}/boost_1_73_0
 
-NATIVE_CXXFLAGS=	-march=native -mtune=native
-NATIVE_CFLAGS=		-march=native -mtune=native
+NATIVE_CXXFLAGS=        -march=native -mtune=native
+NATIVE_CFLAGS=          -march=native -mtune=native
 
-NATIVE_CXXFLAGS_OFF=	-march=core2
-NATIVE_CFLAGS_OFF=	-march=core2
+NATIVE_CXXFLAGS_OFF=    -march=core2
+NATIVE_CFLAGS_OFF=      -march=core2
 
-CFLAGS+=	-fPIC
+CFLAGS+=        -fPIC
 
 .include <bsd.port.options.mk>
 
 .if ${PORT_OPTIONS:MSHARED}
-CMAKE_ARGS+=	-DBUILD_STATIC_AND_SHARED=ON
-PLIST_SUB+=	SHARED="" \
-		SOVERSION=${PORTVERSION} \
-		SOSHORTVERSION=${PORTVERSION:C/\.[0-9].[0-9]$//}
+CMAKE_ARGS+=    -DBUILD_STATIC_AND_SHARED=ON
+PLIST_SUB+=     SHARED="" \
+                SOVERSION=${PORTVERSION} \
+                SOSHORTVERSION=${PORTVERSION:C/\.[0-9].[0-9]$//}
 .else
-PLIST_SUB+=	SHARED="@comment "
+PLIST_SUB+=     SHARED="@comment "
 .endif
 
 # don't build hsbench tool
 post-patch:
-	${RM} ${WRKSRC}/tools/CMakeLists.txt
+        ${RM} ${WRKSRC}/tools/CMakeLists.txt
 
 do-test:
-	cd ${BUILD_WRKSRC} && ${MAKE_CMD} unit
+        cd ${BUILD_WRKSRC} && ${MAKE_CMD} unit
 
 .include <bsd.port.mk>

--- a/devel/hyperscan/distinfo
+++ b/devel/hyperscan/distinfo
@@ -1,5 +1,5 @@
-TIMESTAMP = 1532682273
-SHA256 (boost_1_65_1.tar.gz) = a13de2c8fbad635e6ba9c8f8714a0e6b4264b60a29b964b940a22554705b6b60
-SIZE (boost_1_65_1.tar.gz) = 97448134
-SHA256 (intel-hyperscan-v4.7.0_GH0.tar.gz) = a0c07b48ae80903001ab216b03fdf6359bfd5777b2976de728947725b335e941
-SIZE (intel-hyperscan-v4.7.0_GH0.tar.gz) = 1738159
+TIMESTAMP = 1589114108
+SHA256 (boost_1_73_0.tar.bz2) = 4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402
+SIZE (boost_1_73_0.tar.bz2) = 109247910
+SHA256 (intel-hyperscan-v5.2.1_GH0.tar.gz) = fd879e4ee5ecdd125e3a79ef040886978ae8f1203832d5a3f050c48f17eec867
+SIZE (intel-hyperscan-v5.2.1_GH0.tar.gz) = 1818935


### PR DESCRIPTION
Updated Intel hyperscan to 5.2.1
- Updated dependency boost to 1.73.0

Hyperscan 5.x supported by suricata
- https://github.com/OISF/suricata/blob/master/doc/userguide/performance/hyperscan.rst