### PR TITLE
mail/postfix: Update to Postfix 3.5.11

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -1,7 +1,7 @@
 # Created by: Torsten Blum <torstenb@FreeBSD.org>
 
 PORTNAME=	postfix
-DISTVERSION=	3.5.10
+DISTVERSION=	3.5.11
 PORTREVISION?=	0
 PORTEPOCH=	1
 CATEGORIES=	mail

--- a/mail/postfix/distinfo
+++ b/mail/postfix/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1618155540
-SHA256 (postfix/postfix-3.5.10.tar.gz) = 5bb4d7d72d7512b58f3a31426dcbd394fd354e0a43de21da89466b057a0228f8
-SIZE (postfix/postfix-3.5.10.tar.gz) = 4621130
+TIMESTAMP = 1623677593
+SHA256 (postfix/postfix-3.5.11.tar.gz) = 056c301900ddc10bd529a781571f31d1a1d054e06afc656c946acd4902e84d9f
+SIZE (postfix/postfix-3.5.11.tar.gz) = 4621709


### PR DESCRIPTION
I have updated OPNsense's `mail/postfix` port to version 3.5.11 based on the HardenedBSD port `mail/postfix35`. 
Because of issue #128 (OpenSSL 1.1.1 TLS 1.3 API incompatibility) we have to stay on the 3.5 branch until the issues with LibreSSL are resolved. 

Besides [some minor fixes](http://www.postfix.org/announcements/postfix-3.6.1.html) I may point out the following change:
> Support for Postfix 3.6 compatibility_level syntax, to avoid fatal runtime errors when rolling back from Postfix 3.6 to an earlier supported version, or when sharing Postfix 3.6 configuration files with an earlier supported Postfix version. 

This should allow us to upgrade our configuration to the 3.6 syntax already, to have a much smoother transition to Postfix 3.6 as soon as it is possible to do with LibreSSL. (*I have already reported that I do not expect any major issues.* https://github.com/opnsense/plugins/issues/2409). 

I have built `postfix-sasl` 3.5.11 sucessfully on OPNsense 21.1.7_1 based on these changes with both OpenSSL and LibreSSL. 