### PR TITLE
net/wireguard-tools - rcng script improvements

### DIFF
--- a/net/wireguard-tools/files/wireguard_wgquick.in
+++ b/net/wireguard-tools/files/wireguard_wgquick.in
@@ -82,14 +82,17 @@ load_rc_config $name
 : ${wireguard_stdout="/var/log/wireguard.log"}
 : ${wireguard_stderr="&1"}
 
-if [ -n "${wireguard_stdout}" ]
+if [ "$1" == "start" -o "$1" == "restart" ]
 then
-	exec >"${wireguard_stdout}"
-fi
+	if [ -n "${wireguard_stdout}" ]
+	then
+		exec >"${wireguard_stdout}"
+	fi
 
-if [ -n "${wireguard_stderr}" ]
-then
-	exec 2>"${wireguard_stderr}"
+	if [ -n "${wireguard_stderr}" ]
+	then
+		exec 2>"${wireguard_stderr}"
+	fi
 fi
 
 run_rc_command "$1"

--- a/net/wireguard-tools/files/wireguard_wgquick.in
+++ b/net/wireguard-tools/files/wireguard_wgquick.in
@@ -12,6 +12,10 @@
 #                             (default: "")
 # wireguard_env (str):        Environment variables for the userspace
 #                             implementation. (eg: "LOG_LEVEL=debug")
+# wireguard_stdout (str):     Set the path for the stdout redirection.
+#                             (default: "/var/log/wireguard.log")
+# wireguard_stderr (str):     Set the stderr redirection.
+#                             (default: "&1")
 
 . /etc/rc.subr
 
@@ -75,5 +79,17 @@ load_rc_config $name
 : ${wireguard_enable="NO"}
 : ${wireguard_interfaces=""}
 : ${wireguard_env=""}
+: ${wireguard_stdout="/var/log/wireguard.log"}
+: ${wireguard_stderr="&1"}
+
+if [ -n "${wireguard_stdout}" ]
+then
+	exec >"${wireguard_stdout}"
+fi
+
+if [ -n "${wireguard_stderr}" ]
+then
+	exec 2>"${wireguard_stderr}"
+fi
 
 run_rc_command "$1"

--- a/net/wireguard-tools/files/wireguard_wgquick.in
+++ b/net/wireguard-tools/files/wireguard_wgquick.in
@@ -17,12 +17,11 @@
 
 name=wireguard
 rcvar=wireguard_enable
-extra_commands="reload status"
+extra_commands="reload"
 
 start_cmd="${name}_start"
 stop_cmd="${name}_stop"
 reload_cmd="${name}_reload"
-status_cmd="${name}_status"
 
 wireguard_start()
 {
@@ -57,17 +56,6 @@ wireguard_reload()
 		%%PREFIX%%/bin/wg syncconf ${interface} ${tmpfile}
 		rm -f ${tmpfile}
 	done
-}
-
-wireguard_status()
-{
-	${wireguard_env:+eval export $wireguard_env}
-	wireguard_status="0"
-	for interface in ${wireguard_interfaces}; do
-		%%PREFIX%%/bin/wg show ${interface} || wireguard_status="1"
-	done
-
-	return ${wireguard_status}
 }
 
 load_rc_config $name

--- a/net/wireguard-tools/files/wireguard_wgquick.in
+++ b/net/wireguard-tools/files/wireguard_wgquick.in
@@ -17,11 +17,12 @@
 
 name=wireguard
 rcvar=wireguard_enable
-extra_commands="reload"
+extra_commands="reload status"
 
 start_cmd="${name}_start"
 stop_cmd="${name}_stop"
 reload_cmd="${name}_reload"
+status_cmd="${name}_status"
 
 wireguard_start()
 {
@@ -56,6 +57,17 @@ wireguard_reload()
 		%%PREFIX%%/bin/wg syncconf ${interface} ${tmpfile}
 		rm -f ${tmpfile}
 	done
+}
+
+wireguard_status()
+{
+	${wireguard_env:+eval export $wireguard_env}
+	wireguard_status="0"
+	for interface in ${wireguard_interfaces}; do
+		%%PREFIX%%/bin/wg show ${interface} || wireguard_status="1"
+	done
+
+	return ${wireguard_status}
 }
 
 load_rc_config $name


### PR DESCRIPTION
The wireguard rcng script lacks a status command. I am not quite sure if I should file this here or with upstream (FreeBSD ports), but here's my proposed fix, anyway.

Kind regards,
Patrick