### PR TITLE
Update tailscaled.in

### DIFF
--- a/security/tailscale/files/tailscaled.in
+++ b/security/tailscale/files/tailscaled.in
@@ -2,6 +2,7 @@
 
 # PROVIDE: tailscaled
 # REQUIRE: NETWORKING
+# REQUIRE: miniupnpd
 # KEYWORD: shutdown
 #
 # Add the following lines to /etc/rc.conf.local or /etc/rc.conf


### PR DESCRIPTION
Follow https://tailscale.com/kb/1097/install-opnsense/ .

/etc/rc.conf is set as follows:
tailscaled_enable="YES"
tailscaled_up_args="--accept-dns=false --advertise-routes=192.168.2.0/24"

After reboot, tailscale on the external network cannot connect to the LAN. At this point everything works fine after running the following line: /usr/local/bin/tailscale up --accept-dns=false --advertise-routes=192.168.2.0/24

After many attempts, it was found that /usr/local/etc/rc.d/tailscaled needs to be modified and depends on miniupnpd.