### PR TITLE
add new port: net/py-haproxy-cli

### DIFF
--- a/opnsense/py-haproxy-cli/Makefile
+++ b/opnsense/py-haproxy-cli/Makefile
@@ -1,0 +1,18 @@
+PORTNAME=	haproxy-cli
+PORTVERSION=	0.6.1
+CATEGORIES=	net python
+MASTER_SITES=	PYPI
+PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
+
+MAINTAINER=	freebsd@moov.de
+COMMENT=	Tool to interact with HAProxy
+WWW=		https://github.com/markt-de/haproxy-cli
+
+LICENSE=	GPLv3
+
+USES=		python
+USE_PYTHON=	distutils concurrent autoplist
+
+NO_ARCH=	yes
+
+.include <bsd.port.mk>

--- a/opnsense/py-haproxy-cli/distinfo
+++ b/opnsense/py-haproxy-cli/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1701813827
+SHA256 (haproxy-cli-0.6.1.tar.gz) = 869f8e5c21db8db9a43cc50020d50e4697d2a9141669bc161289e0163d412319
+SIZE (haproxy-cli-0.6.1.tar.gz) = 22513

--- a/opnsense/py-haproxy-cli/pkg-descr
+++ b/opnsense/py-haproxy-cli/pkg-descr
@@ -1,0 +1,7 @@
+haproxy-cli is a tool to manage the various aspects of HAProxy that can be
+controlled by means of its socket.
+
+haproxy-cli can be used in 2 modes: CLI mode and Python API mode. CLI mode,
+as the name implies, gives you a command, haproxy-cli, that can be used to
+control HAProxy. You can use the Python API mode to integrate haproxy-cli
+directly in your Python project.


### PR DESCRIPTION
Required for https://github.com/opnsense/plugins/pull/3694 and https://github.com/opnsense/tools/pull/393.

Note that os-haproxy now requires haproxy-cli, which is waiting to be included in FreeBSD ports:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=275562
Maybe you could import this port so that we don't have to wait for approval. :blush: 