### PR TITLE
net/ndproxy: Remove wrong comment, promisc is always required, regardless of setup

### DIFF
--- a/net/ndproxy/files/ndproxy.in
+++ b/net/ndproxy/files/ndproxy.in
@@ -11,7 +11,6 @@ rcvar=ndproxy_enable
 start_cmd="ndproxy_start"
 stop_cmd="ndproxy_stop"
 
-# Promiscuous mode may be disabled if uplink_interface and downlink_mac_address are same interface
 : ${ndproxy_promisc_enable:=YES}
 
 ndproxy_start()


### PR DESCRIPTION
https://github.com/opnsense/docs/pull/717

We just made it configurable because we want to control it via interface settings reliably.