### PR TITLE
net/tayga: Override config path at compile time

### DIFF
--- a/net/tayga/Makefile
+++ b/net/tayga/Makefile
@@ -13,6 +13,7 @@ LICENSE=	GPLv2
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
 USES=		gmake
+MAKE_ARGS=	CFLAGS="${CFLAGS} -DTAYGA_CONF_PATH=\"/usr/local/etc/tayga.conf\""
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	apalrd


### PR DESCRIPTION
Issue report: https://github.com/opnsense/ports/commit/89079543acdfc27de6f46c19450187b79ee8b13c#commitcomment-160530394
Requires apalrd/tayga#101 to work.