### PR TITLE
Fix config file name in sslocal-rust.in

### DIFF
--- a/net/shadowsocks-rust/files/sslocal-rust.in
+++ b/net/shadowsocks-rust/files/sslocal-rust.in
@@ -19,7 +19,7 @@ pidfile="/var/run/${name}.pid"
 logfile="/var/log/${name}.log"
 
 : ${sslocal_rust_enable="NO"}
-: ${sslocal_rust_args="-c %%ETCDIR%%/config.json"}
+: ${sslocal_rust_args="-c %%ETCDIR%%/local.json"}
 
 procname=%%PREFIX%%/bin/sslocal
 command="/usr/sbin/daemon"


### PR DESCRIPTION
Fixing config file name for local config.

this matches the browser os-shadowsocks UI to set shadowsocks local part up.