### PR TITLE
security/suricata - support so_reuseport_lb for parallel socket binding

### DIFF
--- a/security/suricata/files/patch-src_source-ipfw.c
+++ b/security/suricata/files/patch-src_source-ipfw.c
@@ -1,0 +1,18 @@
+--- src/source-ipfw.c.orig	2025-12-22 19:23:25 UTC
++++ src/source-ipfw.c
+@@ -359,6 +359,15 @@ TmEcode ReceiveIPFWThreadInit(ThreadVars *tv, const vo
+         SCLogError("Can't set IPFW divert socket timeout: %s", strerror(errno));
+         SCReturnInt(TM_ECODE_FAILED);
+     }
++    
++#ifdef PF_DIVERT
++    int one = 1;
++    if (setsockopt(nq->fd, SOL_SOCKET, SO_REUSEPORT_LB, &one, sizeof(one)) == -1) {
++        SCLogError("Can't set IPFW divert socket SO_REUSEPORT_LB: %s", strerror(errno));
++        SCReturnInt(TM_ECODE_FAILED);
++    }
++#endif
++    
+ 
+     nq->ipfw_sinlen=sizeof(nq->ipfw_sin);
+     memset(&nq->ipfw_sin, 0, nq->ipfw_sinlen);


### PR DESCRIPTION
Although our current `divert(4)` implementation combined with `pf(4)` only supports IPv4, I'm quite confident we will support IPv6 in the near future as well, which means with the latest kernel changes in place (divert branch in src) we can offer parallel processing of multiple flows for suricata when `SO_REUSEPORT_LB` is set.

When using `ipfw(8)`, our `divert` src tree already supports the `SO_REUSEPORT_LB` policy for both protocols.

The proposal is to start shipping this patch on our end first so we can aim for 26.1 inclusion and contact the oisf team later for inclusion in the standard distribution when this new option is part of FreeBSD as well.

