### PR TITLE
security/py-gixy: Update WWW to actively maintained fork

### DIFF
--- a/security/py-gixy/Makefile
+++ b/security/py-gixy/Makefile
@@ -6,7 +6,7 @@ PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
 
 MAINTAINER=	dvl@FreeBSD.org
 COMMENT=	Tool to analyze Nginx configuration for security misconfiguration
-WWW=		https://github.com/yandex/gixy
+WWW=		https://github.com/dvershinin/gixy
 
 LICENSE=	APACHE20
 


### PR DESCRIPTION
The original `yandex/gixy` repository has been unmaintained since 2020.

The [`dvershinin/gixy`](https://github.com/dvershinin/gixy) fork (published as `gixy-ng` on PyPI) is actively maintained with:
- Python 3.6+ support (up to 3.13)
- Additional security checks beyond the original
- Regular updates and releases
- Modern dependency support

Official website: https://gixy.org
Documentation: https://gixy.getpagespeed.com

Note: A full port update to `gixy-ng` would be a welcome follow-up enhancement.