### PR TITLE
opnsense/filterlog-go: update to 0.9.0

### DIFF
--- a/opnsense/filterlog-go/Makefile
+++ b/opnsense/filterlog-go/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	opnsense-filterlog
 DISTVERSIONPREFIX=v
-DISTVERSION=	0.8.0
+DISTVERSION=	0.9.0
 CATEGORIES=	sysutils
 
 MAINTAINER=	me@allddd.onl

--- a/opnsense/filterlog-go/distinfo
+++ b/opnsense/filterlog-go/distinfo
@@ -1,5 +1,5 @@
-TIMESTAMP = 1770370813
-SHA256 (go/opnsense_filterlog-go/opnsense-filterlog-v0.8.0/v0.8.0.mod) = c49218f29d4111b47a0fc904d90bbd533e08ddfb6c4142f0d843c1c74fcac4b4
-SIZE (go/opnsense_filterlog-go/opnsense-filterlog-v0.8.0/v0.8.0.mod) = 1330
-SHA256 (go/opnsense_filterlog-go/opnsense-filterlog-v0.8.0/v0.8.0.zip) = 7c5892966adf1de8e1f92d5a562277ea2db3e4a651b9589075ce8f9c47df4f88
-SIZE (go/opnsense_filterlog-go/opnsense-filterlog-v0.8.0/v0.8.0.zip) = 259820
+TIMESTAMP = 1773336406
+SHA256 (go/opnsense_filterlog-go/opnsense-filterlog-v0.9.0/v0.9.0.mod) = d7afd49118478e5c1465438fd1c2293414602937fa91a38663dc1d463f38feb5
+SIZE (go/opnsense_filterlog-go/opnsense-filterlog-v0.9.0/v0.9.0.mod) = 1069
+SHA256 (go/opnsense_filterlog-go/opnsense-filterlog-v0.9.0/v0.9.0.zip) = 4457335db589a782982ec68fa6d43eefb4f27c3faff3466141657fa825991ab1
+SIZE (go/opnsense_filterlog-go/opnsense-filterlog-v0.9.0/v0.9.0.zip) = 381175


### PR DESCRIPTION
https://gitlab.com/allddd/opnsense-filterlog/-/releases/v0.9.0