### PR TITLE
opnsense/filterlog-go: update to 0.10.0

### DIFF
--- a/opnsense/filterlog-go/Makefile
+++ b/opnsense/filterlog-go/Makefile
@@ -1,16 +1,16 @@
 PORTNAME=	opnsense-filterlog
 DISTVERSIONPREFIX=v
-DISTVERSION=	0.9.0
+DISTVERSION=	0.10.0
 CATEGORIES=	sysutils
 
 MAINTAINER=	me@allddd.onl
-COMMENT=	TUI for viewing and analysing OPNsense firewall logs
+COMMENT=	command-line tool and terminal-based viewer for OPNsense firewall logs
 WWW=		https://gitlab.com/allddd/opnsense-filterlog
 
 LICENSE=	BSD2CLAUSE
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
-USES=		go:1.25,modules
+USES=		go:1.26,modules
 CGO_ENABLED=	0
 GO_MODULE=	gitlab.com/allddd/opnsense-filterlog
 GO_TARGET=	.:${PREFIX}/sbin/${PORTNAME}

--- a/opnsense/filterlog-go/distinfo
+++ b/opnsense/filterlog-go/distinfo
@@ -1,5 +1,5 @@
-TIMESTAMP = 1773336406
-SHA256 (go/opnsense_filterlog-go/opnsense-filterlog-v0.9.0/v0.9.0.mod) = d7afd49118478e5c1465438fd1c2293414602937fa91a38663dc1d463f38feb5
-SIZE (go/opnsense_filterlog-go/opnsense-filterlog-v0.9.0/v0.9.0.mod) = 1069
-SHA256 (go/opnsense_filterlog-go/opnsense-filterlog-v0.9.0/v0.9.0.zip) = 4457335db589a782982ec68fa6d43eefb4f27c3faff3466141657fa825991ab1
-SIZE (go/opnsense_filterlog-go/opnsense-filterlog-v0.9.0/v0.9.0.zip) = 381175
+TIMESTAMP = 1777053673
+SHA256 (go/opnsense_filterlog-go/opnsense-filterlog-v0.10.0/v0.10.0.mod) = 76eee68527489de3fcd51618848878a8abe5737843fd844968ccb6a48be1cf1a
+SIZE (go/opnsense_filterlog-go/opnsense-filterlog-v0.10.0/v0.10.0.mod) = 1687
+SHA256 (go/opnsense_filterlog-go/opnsense-filterlog-v0.10.0/v0.10.0.zip) = 2a8d3383b443fe34c08f5b251f2133548028801e76c83bcd23abdd8c8e0feb75
+SIZE (go/opnsense_filterlog-go/opnsense-filterlog-v0.10.0/v0.10.0.zip) = 1371169

--- a/opnsense/filterlog-go/pkg-descr
+++ b/opnsense/filterlog-go/pkg-descr
@@ -1,3 +1,5 @@
-opnsense-filterlog is a terminal-based viewer for OPNsense firewall logs.
-It works similarly to a pager like less, but with filtering/searching
-capabilities built specifically for firewall logs.
+opnsense-filterlog is a command-line tool and terminal-based viewer for
+analyzing OPNsense firewall logs. It can be used either as an interactive TUI
+or to output log entries in JSON format for automation, etc. Both CLI and TUI
+support filtering using a tcpdump-like syntax with field- and time-based
+filters, logical operators, and grouping.


### PR DESCRIPTION
https://gitlab.com/allddd/opnsense-filterlog/-/releases/v0.10.0

go1.26 isn’t really necessary, but any [gc improvements](https://go.dev/doc/go1.26#new-garbage-collector) are pretty nice for a tool like this